### PR TITLE
Buttons refactoring

### DIFF
--- a/_src/pages/create-game/ui/create-game-form/components/footer/footer.tsx
+++ b/_src/pages/create-game/ui/create-game-form/components/footer/footer.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import {
 	ArrowLeftIcon,
 	ArrowRightIcon,
@@ -53,7 +53,7 @@ export function FormFooter(props: Props) {
 			</section>
 			<section className="flex flex-row gap-4">
 				{hasGoBack && (
-					<NewButton
+					<Button
 						variant="ghost"
 						aria-label="Back button"
 						type="button"
@@ -62,10 +62,10 @@ export function FormFooter(props: Props) {
 					>
 						<ArrowLeftIcon size={18} />
 						Back
-					</NewButton>
+					</Button>
 				)}
 				{hasContinue && (
-					<NewButton
+					<Button
 						aria-label="Continue button"
 						isDisabled={!isStepValid}
 						onPress={goNextStep}
@@ -74,10 +74,10 @@ export function FormFooter(props: Props) {
 					>
 						Continue
 						<ArrowRightIcon size={18} />
-					</NewButton>
+					</Button>
 				)}
 				{hasOpenAdvancedSettings && (
-					<NewButton
+					<Button
 						variant="outline"
 						aria-label="Advanced Settings button"
 						onPress={goNextStep}
@@ -87,10 +87,10 @@ export function FormFooter(props: Props) {
 					>
 						Advanced Settings
 						<SettingsIcon size={18} />
-					</NewButton>
+					</Button>
 				)}
 				{hasStartGame && (
-					<NewButton
+					<Button
 						type="submit"
 						aria-label="Start Game button"
 						isDisabled={!isFormValid}
@@ -98,7 +98,7 @@ export function FormFooter(props: Props) {
 						data-testid="start-game-btn"
 					>
 						Start Game
-					</NewButton>
+					</Button>
 				)}
 			</section>
 		</div>

--- a/_src/pages/create-game/ui/create-game-form/components/footer/footer.tsx
+++ b/_src/pages/create-game/ui/create-game-form/components/footer/footer.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import {
 	ArrowLeftIcon,
 	ArrowRightIcon,
@@ -53,48 +53,52 @@ export function FormFooter(props: Props) {
 			</section>
 			<section className="flex flex-row gap-4">
 				{hasGoBack && (
-					<Button
+					<NewButton
 						variant="ghost"
-						contentLeft={ArrowLeftIcon({ size: 18 })}
 						aria-label="Back button"
-						title="Back"
 						type="button"
 						onPress={goPrevStep}
 						data-testid="back-btn"
-					/>
+					>
+						<ArrowLeftIcon size={18} />
+						Back
+					</NewButton>
 				)}
 				{hasContinue && (
-					<Button
-						title="Continue"
+					<NewButton
 						aria-label="Continue button"
-						contentRight={ArrowRightIcon({ size: 18 })}
 						isDisabled={!isStepValid}
 						onPress={goNextStep}
 						type="button"
 						data-testid="continue-btn"
-					/>
+					>
+						Continue
+						<ArrowRightIcon size={18} />
+					</NewButton>
 				)}
 				{hasOpenAdvancedSettings && (
-					<Button
-						title="Advanced Settings"
+					<NewButton
 						variant="outline"
 						aria-label="Advanced Settings button"
-						contentRight={SettingsIcon({ size: 18 })}
 						onPress={goNextStep}
 						isDisabled={!isStepValid}
 						type="button"
 						data-testid="advanced-settings-btn"
-					/>
+					>
+						Advanced Settings
+						<SettingsIcon size={18} />
+					</NewButton>
 				)}
 				{hasStartGame && (
-					<Button
+					<NewButton
 						type="submit"
 						aria-label="Start Game button"
-						title="Start Game"
 						isDisabled={!isFormValid}
 						isPending={isPending}
 						data-testid="start-game-btn"
-					/>
+					>
+						Start Game
+					</NewButton>
 				)}
 			</section>
 		</div>

--- a/_src/pages/game-join-room/ui/game-join-form/game-join-form.tsx
+++ b/_src/pages/game-join-room/ui/game-join-form/game-join-form.tsx
@@ -3,7 +3,7 @@
 import { GameSchemaBuildersMap } from "@/_src/entities/game";
 import { ApiError } from "@/_src/shared/lib";
 import { useApi } from "@/_src/shared/providers";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { FullSizeFormTextInput } from "@/_src/shared/ui/components/full-size-form-text-field";
 import { PlayIcon } from "@/_src/shared/ui/components/icon/svg/play.icon";
 import { ProfileIcon } from "@/_src/shared/ui/components/icon/svg/profile.icon";
@@ -116,7 +116,7 @@ export function GameJoinForm({ gameId }: Props) {
 					</p>
 				</section>
 				<section className="flex flex-row gap-4">
-					<NewButton
+					<Button
 						type="submit"
 						aria-label="Enter the game button"
 						data-testid="enter-game-btn"
@@ -127,7 +127,7 @@ export function GameJoinForm({ gameId }: Props) {
 					>
 						Enter the Game
 						<PlayIcon size={18}  />
-					</NewButton>
+					</Button>
 				</section>
 			</div>
 		</form>

--- a/_src/pages/game-join-room/ui/game-join-form/game-join-form.tsx
+++ b/_src/pages/game-join-room/ui/game-join-form/game-join-form.tsx
@@ -3,7 +3,7 @@
 import { GameSchemaBuildersMap } from "@/_src/entities/game";
 import { ApiError } from "@/_src/shared/lib";
 import { useApi } from "@/_src/shared/providers";
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { FullSizeFormTextInput } from "@/_src/shared/ui/components/full-size-form-text-field";
 import { PlayIcon } from "@/_src/shared/ui/components/icon/svg/play.icon";
 import { ProfileIcon } from "@/_src/shared/ui/components/icon/svg/profile.icon";
@@ -116,17 +116,18 @@ export function GameJoinForm({ gameId }: Props) {
 					</p>
 				</section>
 				<section className="flex flex-row gap-4">
-					<Button
+					<NewButton
 						type="submit"
 						aria-label="Enter the game button"
-						title="Enter the Game"
 						data-testid="enter-game-btn"
 						isDisabled={
 							!!error || !formState.dirtyFields.displayName
 						}
 						isPending={isPending}
-						contentRight={PlayIcon({ size: 18 })}
-					/>
+					>
+						Enter the Game
+						<PlayIcon size={18}  />
+					</NewButton>
 				</section>
 			</div>
 		</form>

--- a/_src/pages/game-room/ui/game-management-bar/game-management-bar.tsx
+++ b/_src/pages/game-room/ui/game-management-bar/game-management-bar.tsx
@@ -5,7 +5,7 @@ import {
 	PeopleIcon,
 	SettingsIcon,
 } from "@/_src/shared/ui/components/icon";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { SlidingSelector } from "@/_src/shared/ui/components/sliding-selector";
 import { GameManagementTab, useGameManagementState } from "../../model";
 import { Tooltip } from "@/_src/shared/ui/components/tooltip";
@@ -77,7 +77,7 @@ export function GameManagementBar({ className }: Props) {
 								const Icon = tabOptions.icon;
 								return (
 									<Tooltip key={ind} delay={0}>
-										<NewButton
+										<Button
 											shape="square"
 											variant="ghost"
 											size="small"
@@ -88,7 +88,7 @@ export function GameManagementBar({ className }: Props) {
 											)}
 										>
 											<Icon size={16} />
-										</NewButton>
+										</Button>
 										<Tooltip.Content>
 											{tabOptions.tooltipText}
 										</Tooltip.Content>

--- a/_src/pages/game-room/ui/game-management-bar/game-management-bar.tsx
+++ b/_src/pages/game-room/ui/game-management-bar/game-management-bar.tsx
@@ -5,7 +5,7 @@ import {
 	PeopleIcon,
 	SettingsIcon,
 } from "@/_src/shared/ui/components/icon";
-import { ButtonSquare } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { SlidingSelector } from "@/_src/shared/ui/components/sliding-selector";
 import { GameManagementTab, useGameManagementState } from "../../model";
 import { Tooltip } from "@/_src/shared/ui/components/tooltip";
@@ -73,23 +73,28 @@ export function GameManagementBar({ className }: Props) {
 						onSelectionReset={() => setActiveTab(null)}
 					>
 						{Object.entries(TAB_BUTTON_OPTIONS).map(
-							([tabType, tabOptions], ind) => (
-								<Tooltip key={ind} delay={0}>
-									<ButtonSquare
-										icon={tabOptions.icon}
-										variant="ghost"
-										size="small"
-										aria-label={tabType}
-										className="group-data-[sliding-selector-element-active=true]:text-primary-500 group-data-[sliding-selector-element-active=true]:hover:text-primary-400 bg-white/0 text-neutral-900 hover:text-neutral-600"
-										onPress={onPanelSelected(
-											tabType as GameManagementTab,
-										)}
-									/>
-									<Tooltip.Content>
-										{tabOptions.tooltipText}
-									</Tooltip.Content>
-								</Tooltip>
-							),
+							([tabType, tabOptions], ind) => {
+								const Icon = tabOptions.icon;
+								return (
+									<Tooltip key={ind} delay={0}>
+										<NewButton
+											shape="square"
+											variant="ghost"
+											size="small"
+											aria-label={tabType}
+											className="group-data-[sliding-selector-element-active=true]:text-primary-500 group-data-[sliding-selector-element-active=true]:hover:text-primary-400 bg-white/0 text-neutral-900 hover:text-neutral-600"
+											onPress={onPanelSelected(
+												tabType as GameManagementTab,
+											)}
+										>
+											<Icon size={16} />
+										</NewButton>
+										<Tooltip.Content>
+											{tabOptions.tooltipText}
+										</Tooltip.Content>
+									</Tooltip>
+								);
+							},
 						)}
 					</SlidingSelector>
 				</GameIntroOnboardingForMaster.Steps.ControlPanelStep>

--- a/_src/pages/game-room/ui/onboardings/onboarding-helper.tsx
+++ b/_src/pages/game-room/ui/onboardings/onboarding-helper.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { List } from "@/_src/shared/ui/components/list";
 import { Popover } from "@/_src/shared/ui/components/popover";
 import { useCallback, useRef, useState } from "react";
@@ -28,9 +28,9 @@ export function OnboardingHelper(props: Props) {
 				<div ref={containerRef}>
 					<Popover>
 						<Highlighter id="quick-guide">
-							<NewButton>
+							<Button>
 								<FlashWithLinesIcon size={18} /> Quick Guide
-							</NewButton>
+							</Button>
 						</Highlighter>
 						<Popover.Content
 							triggerRef={containerRef}
@@ -47,7 +47,7 @@ export function OnboardingHelper(props: Props) {
 											Onboarding List
 										</h1>
 										<Tooltip>
-											<NewButton
+											<Button
 												shape="square"
 												size="small"
 												variant="ghost"
@@ -56,7 +56,7 @@ export function OnboardingHelper(props: Props) {
 												onPress={dismiss}
 											>
 												<CloseIcon size={20} />
-											</NewButton>
+											</Button>
 											<Tooltip.Content>
 												Dismiss
 											</Tooltip.Content>

--- a/_src/pages/game-room/ui/participants-panel/game-link-clipboard-copier/game-link-clipboard-copier.tsx
+++ b/_src/pages/game-room/ui/participants-panel/game-link-clipboard-copier/game-link-clipboard-copier.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { CopyIcon, CopySuccessIcon } from "@/_src/shared/ui/components/icon";
 import { Input } from "@/_src/shared/ui/components/input";
 import { Tooltip } from "@/_src/shared/ui/components/tooltip";
@@ -34,7 +34,7 @@ export function GameLinkClipboardCopier() {
 				value={window.location.href}
 			/>
 			<Tooltip isOpen={isCopied}>
-				<NewButton
+				<Button
 					shape="square"
 					variant="ghost"
 					className={copyBtnStyles({ isCopied })}
@@ -45,7 +45,7 @@ export function GameLinkClipboardCopier() {
 					) : (
 						<CopyIcon size={18} />
 					)}
-				</NewButton>
+				</Button>
 				<Tooltip.Content>Copied 🎉</Tooltip.Content>
 			</Tooltip>
 		</div>

--- a/_src/pages/game-room/ui/participants-panel/game-link-clipboard-copier/game-link-clipboard-copier.tsx
+++ b/_src/pages/game-room/ui/participants-panel/game-link-clipboard-copier/game-link-clipboard-copier.tsx
@@ -1,4 +1,4 @@
-import { ButtonSquare } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { CopyIcon, CopySuccessIcon } from "@/_src/shared/ui/components/icon";
 import { Input } from "@/_src/shared/ui/components/input";
 import { Tooltip } from "@/_src/shared/ui/components/tooltip";
@@ -34,12 +34,18 @@ export function GameLinkClipboardCopier() {
 				value={window.location.href}
 			/>
 			<Tooltip isOpen={isCopied}>
-				<ButtonSquare
-					icon={isCopied ? CopySuccessIcon : CopyIcon}
+				<NewButton
+					shape="square"
 					variant="ghost"
 					className={copyBtnStyles({ isCopied })}
 					onPress={copyToClipboard}
-				/>
+				>
+					{isCopied ? (
+						<CopySuccessIcon size={18} />
+					) : (
+						<CopyIcon size={18} />
+					)}
+				</NewButton>
 				<Tooltip.Content>Copied 🎉</Tooltip.Content>
 			</Tooltip>
 		</div>

--- a/_src/pages/game-room/ui/participants-panel/participant-list-item/participant-list-item.tsx
+++ b/_src/pages/game-room/ui/participants-panel/participant-list-item/participant-list-item.tsx
@@ -5,7 +5,7 @@ import {
 	useGameState,
 } from "../../../model";
 import { Menu } from "@/_src/shared/ui/components/menu";
-import { ButtonSquare } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { MoreIcon } from "@/_src/shared/ui/components/icon";
 import { Avatar } from "@/_src/shared/ui/components/avatar";
 import { useMemo } from "react";
@@ -46,11 +46,13 @@ export function ParticipantListItem({
 				</div>
 				{options.length > 0 && (
 					<Menu>
-						<ButtonSquare
-							icon={MoreIcon}
+						<NewButton
+							shape="square"
 							variant="ghost"
 							className="shrink-0"
-						/>
+						>
+							<MoreIcon size={18} />
+						</NewButton>
 						<Menu.Content placement="bottom end">
 							<Menu.Section title="Options">
 								{options.map(({ title, icon, action }) => (

--- a/_src/pages/game-room/ui/participants-panel/participant-list-item/participant-list-item.tsx
+++ b/_src/pages/game-room/ui/participants-panel/participant-list-item/participant-list-item.tsx
@@ -5,7 +5,7 @@ import {
 	useGameState,
 } from "../../../model";
 import { Menu } from "@/_src/shared/ui/components/menu";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { MoreIcon } from "@/_src/shared/ui/components/icon";
 import { Avatar } from "@/_src/shared/ui/components/avatar";
 import { useMemo } from "react";
@@ -46,13 +46,13 @@ export function ParticipantListItem({
 				</div>
 				{options.length > 0 && (
 					<Menu>
-						<NewButton
+						<Button
 							shape="square"
 							variant="ghost"
 							className="shrink-0"
 						>
 							<MoreIcon size={18} />
-						</NewButton>
+						</Button>
 						<Menu.Content placement="bottom end">
 							<Menu.Section title="Options">
 								{options.map(({ title, icon, action }) => (

--- a/_src/pages/game-room/ui/poker-field/poker-table/components/voting-actions.tsx
+++ b/_src/pages/game-room/ui/poker-field/poker-table/components/voting-actions.tsx
@@ -8,7 +8,7 @@ import {
 	useVotingAsyncState,
 } from "@/_src/pages/game-room/model";
 import { GameVotingStatus } from "@/_src/shared/api";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { CardsIcon, RefreshIcon } from "@/_src/shared/ui/components/icon";
 import { TicketLink } from "../../ticket-link";
 import { useCallback } from "react";
@@ -72,10 +72,10 @@ export function VotingActions() {
 						Start from creating tickets 👇
 					</p>
 					<Highlighter id="start-creating-tickets">
-						<NewButton onPress={onTicketListLinkPress}>
+						<Button onPress={onTicketListLinkPress}>
 							<CardsIcon size={18} />
 							Open Tickets Panel
-						</NewButton>
+						</Button>
 					</Highlighter>
 				</div>
 			)}
@@ -90,10 +90,10 @@ export function VotingActions() {
 						</span>
 					</p>
 					<Highlighter id="start-creating-tickets">
-						<NewButton onPress={voteForFirstTicket}>
+						<Button onPress={voteForFirstTicket}>
 							<CardsIcon size={18} />
 							Vote for {firstUnestimatedTicket.identifier}
-						</NewButton>
+						</Button>
 					</Highlighter>
 				</div>
 			)}
@@ -109,22 +109,22 @@ export function VotingActions() {
 			{votingProcess.status === GameVotingStatus.InProgress && (
 				<div className="flex flex-col items-center gap-2">
 					<div className="flex flex-row gap-2">
-						<NewButton
+						<Button
 							onPress={revealCards}
 							isPending={isRevealCardsPending}
 							className="min-w-max"
 						>
 							<CardsIcon size={24} />
 							Reveal Cards
-						</NewButton>
-						<NewButton
+						</Button>
+						<Button
 							onPress={cancelVoting}
 							variant="outline"
 							isPending={isCancelVotingPending}
 							className="min-w-max"
 						>
 							Cancel Voting
-						</NewButton>
+						</Button>
 					</div>
 					{votingProcess.ticket === null ? (
 						<p className="text-sm text-neutral-900">
@@ -145,14 +145,14 @@ export function VotingActions() {
 			)}
 			{votingProcess.status === GameVotingStatus.Revealed && (
 				<div className="flex flex-row gap-2">
-					<NewButton
+					<Button
 						className="w-max"
 						onPress={finishVoting}
 						isPending={isFinishVotingPending}
 					>
 						Finish Voting
-					</NewButton>
-					<NewButton
+					</Button>
+					<Button
 						variant="outline"
 						className="border"
 						onPress={onRevote}
@@ -160,7 +160,7 @@ export function VotingActions() {
 					>
 						<RefreshIcon size={24} />
 						Revote
-					</NewButton>
+					</Button>
 				</div>
 			)}
 		</>

--- a/_src/pages/game-room/ui/poker-field/poker-table/components/voting-actions.tsx
+++ b/_src/pages/game-room/ui/poker-field/poker-table/components/voting-actions.tsx
@@ -8,7 +8,7 @@ import {
 	useVotingAsyncState,
 } from "@/_src/pages/game-room/model";
 import { GameVotingStatus } from "@/_src/shared/api";
-import { Button, NewButton } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { CardsIcon, RefreshIcon } from "@/_src/shared/ui/components/icon";
 import { TicketLink } from "../../ticket-link";
 import { useCallback } from "react";
@@ -145,20 +145,22 @@ export function VotingActions() {
 			)}
 			{votingProcess.status === GameVotingStatus.Revealed && (
 				<div className="flex flex-row gap-2">
-					<Button
-						title="Finish Voting"
+					<NewButton
 						className="w-max"
 						onPress={finishVoting}
 						isPending={isFinishVotingPending}
-					/>
-					<Button
-						title="Revote"
-						contentLeft={<RefreshIcon size={24} />}
+					>
+						Finish Voting
+					</NewButton>
+					<NewButton
 						variant="outline"
 						className="border"
 						onPress={onRevote}
 						isPending={isStartVotingPending}
-					/>
+					>
+						<RefreshIcon size={24} />
+						Revote
+					</NewButton>
 				</div>
 			)}
 		</>

--- a/_src/pages/game-room/ui/poker-field/poker-table/components/voting-info.tsx
+++ b/_src/pages/game-room/ui/poker-field/poker-table/components/voting-info.tsx
@@ -11,7 +11,7 @@ import { TicketLink } from "../../ticket-link";
 import { GameVotingStatus } from "@/_src/shared/api";
 import { Link, LinkButton } from "@/_src/shared/ui/components/link";
 import { Modal } from "@/_src/shared/ui/components/modal";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { CloseIcon } from "@/_src/shared/ui/components/icon";
 import { ReactNode } from "react";
 
@@ -98,13 +98,13 @@ function LearnMoreDialog({ children }: { children: ReactNode }) {
 					<>
 						<Modal.Header>
 							<Modal.Title>What&apos;s going on?</Modal.Title>
-							<NewButton
+							<Button
 								variant="ghost"
 								onPress={close}
 								shape="square"
 							>
 								<CloseIcon size={20} />
-							</NewButton>
+							</Button>
 						</Modal.Header>
 						<Modal.Body>
 							<p className="">
@@ -141,7 +141,7 @@ function LearnMoreDialog({ children }: { children: ReactNode }) {
 						</Modal.Body>
 						<Modal.Footer>
 							{({ close }) => (
-								<NewButton onPress={close}>Ok</NewButton>
+								<Button onPress={close}>Ok</Button>
 							)}
 						</Modal.Footer>
 					</>

--- a/_src/pages/game-room/ui/poker-field/voting-results/components/voting-results-applier.tsx
+++ b/_src/pages/game-room/ui/poker-field/voting-results/components/voting-results-applier.tsx
@@ -7,7 +7,7 @@ import {
 	useTicketUpdate,
 	useVotingAsyncState,
 } from "../../../../model";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { Select } from "@/_src/shared/ui/components/select";
 import type { Key, Selection } from "@react-types/shared";
 import { useCallback, useMemo, useState } from "react";
@@ -126,13 +126,13 @@ function VotingResultsApplierInner(props: InnerProps) {
 				)}
 			</Select>
 
-			<NewButton
+			<Button
 				data-testid="apply-voting-results-btn"
 				isDisabled={!selectedVoteId}
 				onPress={onApplyPress}
 			>
 				Apply
-			</NewButton>
+			</Button>
 		</div>
 	);
 }

--- a/_src/pages/game-room/ui/poker-field/voting-results/components/voting-results-applier.tsx
+++ b/_src/pages/game-room/ui/poker-field/voting-results/components/voting-results-applier.tsx
@@ -7,7 +7,7 @@ import {
 	useTicketUpdate,
 	useVotingAsyncState,
 } from "../../../../model";
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { Select } from "@/_src/shared/ui/components/select";
 import type { Key, Selection } from "@react-types/shared";
 import { useCallback, useMemo, useState } from "react";
@@ -126,12 +126,13 @@ function VotingResultsApplierInner(props: InnerProps) {
 				)}
 			</Select>
 
-			<Button
-				title="Apply"
+			<NewButton
 				data-testid="apply-voting-results-btn"
 				isDisabled={!selectedVoteId}
 				onPress={onApplyPress}
-			/>
+			>
+				Apply
+			</NewButton>
 		</div>
 	);
 }

--- a/_src/pages/game-room/ui/tickets-panel/components/ticket-creator/components/ticket-creator-form.tsx
+++ b/_src/pages/game-room/ui/tickets-panel/components/ticket-creator/components/ticket-creator-form.tsx
@@ -8,7 +8,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Controller, useForm } from "react-hook-form";
 import { TicketTypeSelector } from "../../ticket-type-selector";
 import { Input } from "@/_src/shared/ui/components/input";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { ArrowRightIcon } from "@/_src/shared/ui/components/icon";
 import { useTicketCreate } from "@/_src/pages/game-room/model";
 import { ErrorBoundary } from "@/_src/shared/ui/components/error-boundary";
@@ -84,7 +84,7 @@ function TicketCreatorFormInner({ onSubmitSucceed }: Props) {
 			/>
 
 			{isValid && (
-				<NewButton
+				<Button
 					shape="square"
 					variant="ghost"
 					data-testid="ticket-creator-submit"
@@ -93,7 +93,7 @@ function TicketCreatorFormInner({ onSubmitSucceed }: Props) {
 					size="small"
 				>
 					<ArrowRightIcon size={18} />
-				</NewButton>
+				</Button>
 			)}
 		</form>
 	);

--- a/_src/pages/game-room/ui/tickets-panel/components/ticket-creator/components/ticket-creator-opener.tsx
+++ b/_src/pages/game-room/ui/tickets-panel/components/ticket-creator/components/ticket-creator-opener.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { Highlighter } from "@/_src/shared/ui/components/highlighter";
 import { PlusIcon } from "@/_src/shared/ui/components/icon";
 import { cva } from "class-variance-authority";
@@ -11,7 +11,7 @@ type Props = {
 export function TicketCreatorOpener({ isOpened, onPress }: Props) {
 	return (
 		<Highlighter id="new-ticket-btn">
-			<NewButton
+			<Button
 				data-state="button"
 				data-testid="ticket-creator-toggler"
 				variant={isOpened ? "outline" : "default"}
@@ -20,7 +20,7 @@ export function TicketCreatorOpener({ isOpened, onPress }: Props) {
 			>
 				<PlusIcon size={25} />
 				{!isOpened && "New Ticket"}
-			</NewButton>
+			</Button>
 		</Highlighter>
 	);
 }

--- a/_src/pages/game-room/ui/tickets-panel/components/ticket-list-item/components/ticket-item-full-view.tsx
+++ b/_src/pages/game-room/ui/tickets-panel/components/ticket-list-item/components/ticket-item-full-view.tsx
@@ -1,5 +1,5 @@
 import { GameTicket } from "@/_src/shared/api/game-api";
-import { ButtonSquare } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { MinusIcon } from "@/_src/shared/ui/components/icon/svg/minus.icon";
 import { Tooltip } from "@/_src/shared/ui/components/tooltip";
 import { Controller, useForm } from "react-hook-form";
@@ -68,13 +68,15 @@ export function TicketItemFullView(props: Props) {
 					</div>
 					<div className="flex flex-row">
 						<Tooltip delay={0}>
-							<ButtonSquare
-								icon={MinusIcon}
+							<NewButton
+								shape="square"
 								variant="ghost"
 								size="small"
 								data-testid="collapse-button"
 								onPress={onClose}
-							/>
+							>
+								<MinusIcon size={16} />
+							</NewButton>
 							<Tooltip.Content>Collapse</Tooltip.Content>
 						</Tooltip>
 						<Tooltip delay={0}>

--- a/_src/pages/game-room/ui/tickets-panel/components/ticket-list-item/components/ticket-item-full-view.tsx
+++ b/_src/pages/game-room/ui/tickets-panel/components/ticket-list-item/components/ticket-item-full-view.tsx
@@ -1,5 +1,5 @@
 import { GameTicket } from "@/_src/shared/api/game-api";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { MinusIcon } from "@/_src/shared/ui/components/icon/svg/minus.icon";
 import { Tooltip } from "@/_src/shared/ui/components/tooltip";
 import { Controller, useForm } from "react-hook-form";
@@ -68,7 +68,7 @@ export function TicketItemFullView(props: Props) {
 					</div>
 					<div className="flex flex-row">
 						<Tooltip delay={0}>
-							<NewButton
+							<Button
 								shape="square"
 								variant="ghost"
 								size="small"
@@ -76,7 +76,7 @@ export function TicketItemFullView(props: Props) {
 								onPress={onClose}
 							>
 								<MinusIcon size={16} />
-							</NewButton>
+							</Button>
 							<Tooltip.Content>Collapse</Tooltip.Content>
 						</Tooltip>
 						<Tooltip delay={0}>

--- a/_src/pages/game-room/ui/tickets-panel/components/ticket-list-item/components/ticket-item-menu.tsx
+++ b/_src/pages/game-room/ui/tickets-panel/components/ticket-list-item/components/ticket-item-menu.tsx
@@ -1,4 +1,4 @@
-import { ButtonSquare } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { MoreIcon } from "@/_src/shared/ui/components/icon/svg/more.icon";
 import { Menu } from "@/_src/shared/ui/components/menu";
 import { twMerge } from "tailwind-merge";
@@ -19,13 +19,15 @@ export function TicketItemMenu(props: Props) {
 
 	return (
 		<Menu>
-			<ButtonSquare
-				icon={MoreIcon}
+			<NewButton
+				shape="square"
 				variant="ghost"
 				className={twMerge("shrink-0", className)}
 				size="small"
 				data-testid="ticket-item-menu"
-			/>
+			>
+				<MoreIcon size={16} />
+			</NewButton>
 			<Menu.Content placement="bottom end">
 				{options.map((option) => (
 					<Menu.Item

--- a/_src/pages/game-room/ui/tickets-panel/components/ticket-list-item/components/ticket-item-menu.tsx
+++ b/_src/pages/game-room/ui/tickets-panel/components/ticket-list-item/components/ticket-item-menu.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { MoreIcon } from "@/_src/shared/ui/components/icon/svg/more.icon";
 import { Menu } from "@/_src/shared/ui/components/menu";
 import { twMerge } from "tailwind-merge";
@@ -19,7 +19,7 @@ export function TicketItemMenu(props: Props) {
 
 	return (
 		<Menu>
-			<NewButton
+			<Button
 				shape="square"
 				variant="ghost"
 				className={twMerge("shrink-0", className)}
@@ -27,7 +27,7 @@ export function TicketItemMenu(props: Props) {
 				data-testid="ticket-item-menu"
 			>
 				<MoreIcon size={16} />
-			</NewButton>
+			</Button>
 			<Menu.Content placement="bottom end">
 				{options.map((option) => (
 					<Menu.Item

--- a/_src/pages/game-room/ui/tickets-panel/components/ticket-list-item/components/vote-button.tsx
+++ b/_src/pages/game-room/ui/tickets-panel/components/ticket-list-item/components/vote-button.tsx
@@ -5,7 +5,7 @@ import {
 	useVotingAsyncState,
 } from "@/_src/pages/game-room/model";
 import { GameTicket, GameVotingStatus } from "@/_src/shared/api";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { Highlighter } from "@/_src/shared/ui/components/highlighter";
 import { CardsIcon } from "@/_src/shared/ui/components/icon";
 import { useCallback } from "react";
@@ -29,7 +29,7 @@ export function VoteButton({ ticket }: Props) {
 	if (status === "ready-to-vote") {
 		return (
 			<Highlighter id="vote-button-in-the-ticket">
-				<NewButton
+				<Button
 					variant="outline"
 					className="border-neutral-300 drop-shadow-none"
 					data-testid={`vote-button-test-${ticket.id}`}
@@ -38,7 +38,7 @@ export function VoteButton({ ticket }: Props) {
 				>
 					<CardsIcon size={16} />
 					VOTE
-				</NewButton>
+				</Button>
 			</Highlighter>
 		);
 	}

--- a/_src/pages/game-room/ui/tickets-panel/components/ticket-type-selector/ticket-type-selector.tsx
+++ b/_src/pages/game-room/ui/tickets-panel/components/ticket-type-selector/ticket-type-selector.tsx
@@ -1,5 +1,5 @@
 import { TicketType } from "@/_src/shared/api/game-api";
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import {
 	TicketBugIcon,
 	TicketStoryIcon,
@@ -26,15 +26,15 @@ export function TicketTypeSelector({
 
 	return (
 		<Menu>
-			<Button
-				title=""
+			<NewButton
 				className="px-2"
-				contentLeft={selectedTypeObj?.icon}
 				variant="ghost"
 				size="small"
 				data-testid="ticket-type-selector"
 				isDisabled={!isEditable}
-			/>
+			>
+				{selectedTypeObj?.icon}
+			</NewButton>
 			<Menu.Content
 				items={TASK_TYPES}
 				selectionMode="single"

--- a/_src/pages/game-room/ui/tickets-panel/components/ticket-type-selector/ticket-type-selector.tsx
+++ b/_src/pages/game-room/ui/tickets-panel/components/ticket-type-selector/ticket-type-selector.tsx
@@ -1,5 +1,5 @@
 import { TicketType } from "@/_src/shared/api/game-api";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import {
 	TicketBugIcon,
 	TicketStoryIcon,
@@ -26,7 +26,7 @@ export function TicketTypeSelector({
 
 	return (
 		<Menu>
-			<NewButton
+			<Button
 				className="px-2"
 				variant="ghost"
 				size="small"
@@ -34,7 +34,7 @@ export function TicketTypeSelector({
 				isDisabled={!isEditable}
 			>
 				{selectedTypeObj?.icon}
-			</NewButton>
+			</Button>
 			<Menu.Content
 				items={TASK_TYPES}
 				selectionMode="single"

--- a/_src/pages/game-room/ui/user-bar/user-bar.tsx
+++ b/_src/pages/game-room/ui/user-bar/user-bar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { LogoutIcon } from "@/_src/shared/ui/components/icon";
 import { Menu } from "@/_src/shared/ui/components/menu";
 import { selectCurrentParticipant, useGameState } from "../../model";
@@ -45,10 +45,11 @@ export function UserBar({ onLogout }: Props) {
 
 	return (
 		<Menu>
-			<Button
+			<NewButton
 				className="w-10 h-10 rounded-full shadow-lg shadow-primary-200 drop-shadow-xl"
-				title={initials}
-			/>
+			>
+				{initials}
+			</NewButton>
 			<Menu.Content placement="bottom end">
 				<Menu.Section title={currentParticipant.displayName}>
 					{/* <Menu.Item isDisabled>

--- a/_src/pages/game-room/ui/user-bar/user-bar.tsx
+++ b/_src/pages/game-room/ui/user-bar/user-bar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { LogoutIcon } from "@/_src/shared/ui/components/icon";
 import { Menu } from "@/_src/shared/ui/components/menu";
 import { selectCurrentParticipant, useGameState } from "../../model";
@@ -45,11 +45,11 @@ export function UserBar({ onLogout }: Props) {
 
 	return (
 		<Menu>
-			<NewButton
+			<Button
 				className="w-10 h-10 rounded-full shadow-lg shadow-primary-200 drop-shadow-xl"
 			>
 				{initials}
-			</NewButton>
+			</Button>
 			<Menu.Content placement="bottom end">
 				<Menu.Section title={currentParticipant.displayName}>
 					{/* <Menu.Item isDisabled>

--- a/_src/pages/main/ui/coming-soon-section.tsx
+++ b/_src/pages/main/ui/coming-soon-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import JiraIntegration from "@public/jira-integration.png";
 import AsyncEstimation from "@public/async-estimation.png";
 import AIAssistant from "@public/ai-assistant.png";
@@ -36,30 +36,30 @@ export function ComingSoonSection() {
 					containerClassName="flex flex-row sm:gap-4 rounded-2xl md:rounded-full bg-neutral-100 border border-neutral-300 p-2 items-center justify-between *:z-15"
 					selectorClassName="bg-white rounded-xl md:rounded-full z-10! drop-shadow-sm border-neutral-200 duration-400"
 				>
-					<NewButton
+					<Button
 						variant="ghost"
 						className="flex h-fit flex-col rounded-xl bg-transparent py-1 md:h-10 md:flex-row lg:rounded-full"
 						onPress={() => setActiveTabInd(0)}
 					>
 						<LinkIcon size={16} thikness="bold" />
 						Jira Integration
-					</NewButton>
-					<NewButton
+					</Button>
+					<Button
 						variant="ghost"
 						className="flex h-fit flex-col rounded-xl bg-transparent py-1 md:h-10 md:flex-row lg:rounded-full"
 						onPress={() => setActiveTabInd(1)}
 					>
 						<ClockIcon size={16} thikness="bold" />
 						Asynchronous Estimation
-					</NewButton>
-					<NewButton
+					</Button>
+					<Button
 						variant="ghost"
 						className="flex h-fit flex-col rounded-xl bg-transparent py-1 md:h-10 md:flex-row lg:rounded-full"
 						onPress={() => setActiveTabInd(2)}
 					>
 						<MagicPenIcon size={16} thikness="bold" />
 						AI Assistant
-					</NewButton>
+					</Button>
 				</SlidingSelector>
 				{tabContent && (
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:h-[310px]">

--- a/_src/pages/main/ui/coming-soon-section.tsx
+++ b/_src/pages/main/ui/coming-soon-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import JiraIntegration from "@public/jira-integration.png";
 import AsyncEstimation from "@public/async-estimation.png";
 import AIAssistant from "@public/ai-assistant.png";
@@ -36,27 +36,30 @@ export function ComingSoonSection() {
 					containerClassName="flex flex-row sm:gap-4 rounded-2xl md:rounded-full bg-neutral-100 border border-neutral-300 p-2 items-center justify-between *:z-15"
 					selectorClassName="bg-white rounded-xl md:rounded-full z-10! drop-shadow-sm border-neutral-200 duration-400"
 				>
-					<Button
-						contentLeft={<LinkIcon size={16} thikness="bold" />}
-						title="Jira Integration"
+					<NewButton
 						variant="ghost"
 						className="flex h-fit flex-col rounded-xl bg-transparent py-1 md:h-10 md:flex-row lg:rounded-full"
 						onPress={() => setActiveTabInd(0)}
-					/>
-					<Button
-						contentLeft={<ClockIcon size={16} thikness="bold" />}
-						title="Asynchronous Estimation"
+					>
+						<LinkIcon size={16} thikness="bold" />
+						Jira Integration
+					</NewButton>
+					<NewButton
 						variant="ghost"
 						className="flex h-fit flex-col rounded-xl bg-transparent py-1 md:h-10 md:flex-row lg:rounded-full"
 						onPress={() => setActiveTabInd(1)}
-					/>
-					<Button
-						contentLeft={<MagicPenIcon size={16} thikness="bold" />}
-						title="AI Assistant"
+					>
+						<ClockIcon size={16} thikness="bold" />
+						Asynchronous Estimation
+					</NewButton>
+					<NewButton
 						variant="ghost"
 						className="flex h-fit flex-col rounded-xl bg-transparent py-1 md:h-10 md:flex-row lg:rounded-full"
 						onPress={() => setActiveTabInd(2)}
-					/>
+					>
+						<MagicPenIcon size={16} thikness="bold" />
+						AI Assistant
+					</NewButton>
 				</SlidingSelector>
 				{tabContent && (
 					<div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:h-[310px]">

--- a/_src/pages/main/ui/header.tsx
+++ b/_src/pages/main/ui/header.tsx
@@ -5,7 +5,7 @@ import { NextLinkButton } from "@/_src/shared/ui/next-components/next-link";
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { useGSAP } from "@gsap/react";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { MenuIcon } from "@/_src/shared/ui/components/icon/svg/menu.icon";
 import { CloseIcon } from "@/_src/shared/ui/components/icon/svg/close.icon";
 import { Modal, ModalOverlay } from "react-aria-components";
@@ -83,13 +83,13 @@ export function Header({ containerRef }: HeaderProps) {
 	const renderCTAs = () => {
 		return (
 			<>
-				<NewButton
+				<Button
 					className="min-w-fit no-underline"
 					variant="outline"
 					onPress={() => onNavLinkPress("/#subscribe")}
 				>
 					Get Updates
-				</NewButton>
+				</Button>
 				<NextLinkButton
 					className="min-w-fit no-underline"
 					href="/create-game"
@@ -131,7 +131,7 @@ export function Header({ containerRef }: HeaderProps) {
 					</Link>
 				</AnimatedFadeIn>
 
-				<NewButton
+				<Button
 					shape="square"
 					variant="ghost"
 					size="large"
@@ -143,7 +143,7 @@ export function Header({ containerRef }: HeaderProps) {
 					) : (
 						<MenuIcon size={24} />
 					)}
-				</NewButton>
+				</Button>
 				<ModalOverlay
 					ref={modalRef}
 					isOpen={isMenuOpen}

--- a/_src/pages/main/ui/header.tsx
+++ b/_src/pages/main/ui/header.tsx
@@ -5,7 +5,7 @@ import { NextLinkButton } from "@/_src/shared/ui/next-components/next-link";
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { useGSAP } from "@gsap/react";
-import { ButtonSquare, NewButton } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { MenuIcon } from "@/_src/shared/ui/components/icon/svg/menu.icon";
 import { CloseIcon } from "@/_src/shared/ui/components/icon/svg/close.icon";
 import { Modal, ModalOverlay } from "react-aria-components";
@@ -131,13 +131,19 @@ export function Header({ containerRef }: HeaderProps) {
 					</Link>
 				</AnimatedFadeIn>
 
-				<ButtonSquare
-					icon={isMenuOpen ? CloseIcon : MenuIcon}
+				<NewButton
+					shape="square"
 					variant="ghost"
 					size="large"
 					className="z-20 bg-transparent xl:hidden"
 					onPress={isMenuOpen ? closeMenu : openMenu}
-				/>
+				>
+					{isMenuOpen ? (
+						<CloseIcon size={24} />
+					) : (
+						<MenuIcon size={24} />
+					)}
+				</NewButton>
 				<ModalOverlay
 					ref={modalRef}
 					isOpen={isMenuOpen}

--- a/_src/pages/main/ui/subscribe-section.tsx
+++ b/_src/pages/main/ui/subscribe-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useApi } from "@/_src/shared/providers";
 import { AnimatedText } from "@/_src/shared/ui/components/animated-text";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { MailIcon } from "@/_src/shared/ui/components/icon/svg/mail.icon";
 import { Input } from "@/_src/shared/ui/components/input";
 import { useActionState } from "react";
@@ -59,12 +59,12 @@ export function SubscribeSection() {
 								isPending={isPending}
 								errors={error}
 							/>
-							<NewButton
+							<Button
 								type="submit"
 								isPending={isPending}
 							>
 								Subscribe
-							</NewButton>
+							</Button>
 						</form>
 					)}
 					{successMsg && (

--- a/_src/pages/main/ui/subscribe-section.tsx
+++ b/_src/pages/main/ui/subscribe-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useApi } from "@/_src/shared/providers";
 import { AnimatedText } from "@/_src/shared/ui/components/animated-text";
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { MailIcon } from "@/_src/shared/ui/components/icon/svg/mail.icon";
 import { Input } from "@/_src/shared/ui/components/input";
 import { useActionState } from "react";
@@ -59,11 +59,12 @@ export function SubscribeSection() {
 								isPending={isPending}
 								errors={error}
 							/>
-							<Button
-								title="Subscribe"
+							<NewButton
 								type="submit"
 								isPending={isPending}
-							/>
+							>
+								Subscribe
+							</NewButton>
 						</form>
 					)}
 					{successMsg && (

--- a/_src/shared/providers/__tests__/confirmation-modal-provider.test.tsx
+++ b/_src/shared/providers/__tests__/confirmation-modal-provider.test.tsx
@@ -1,7 +1,7 @@
 import { test, describe, expect, vi } from "vitest";
 import { render } from "@/test/utilities";
 
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import {
 	ConfirmationModalProvider,
 	useConfirmationModal,
@@ -21,7 +21,7 @@ function ModalController({
 }: Props) {
 	const { open } = useConfirmationModal();
 	return (
-		<NewButton
+		<Button
 			data-testid="opener"
 			onPress={() =>
 				open({
@@ -33,7 +33,7 @@ function ModalController({
 			}
 		>
 			Open Modal
-		</NewButton>
+		</Button>
 	);
 }
 function getComponent(props: Props) {

--- a/_src/shared/providers/__tests__/confirmation-modal-provider.test.tsx
+++ b/_src/shared/providers/__tests__/confirmation-modal-provider.test.tsx
@@ -1,7 +1,7 @@
 import { test, describe, expect, vi } from "vitest";
 import { render } from "@/test/utilities";
 
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import {
 	ConfirmationModalProvider,
 	useConfirmationModal,
@@ -21,8 +21,7 @@ function ModalController({
 }: Props) {
 	const { open } = useConfirmationModal();
 	return (
-		<Button
-			title="Open Modal"
+		<NewButton
 			data-testid="opener"
 			onPress={() =>
 				open({
@@ -32,7 +31,9 @@ function ModalController({
 					onConfirm,
 				})
 			}
-		/>
+		>
+			Open Modal
+		</NewButton>
 	);
 }
 function getComponent(props: Props) {

--- a/_src/shared/ui/components/autocomplete/components/autocomplete-value.tsx
+++ b/_src/shared/ui/components/autocomplete/components/autocomplete-value.tsx
@@ -20,7 +20,7 @@ import {
 	FieldError,
 } from "react-aria-components";
 import { useAutocompleteValue } from "../hooks/use-autocomplete-value";
-import { NewButton } from "../../button";
+import { Button } from "../../button";
 import { ArrowDownIcon, WarningIcon } from "../../icon";
 import { Chip, ChipGroup } from "../../chip";
 import { cva } from "class-variance-authority";
@@ -56,7 +56,7 @@ function AutocompleteSingleValue() {
 					[ButtonContext, { isPressed: overlayTriggerState?.isOpen }],
 				]}
 			>
-				<NewButton
+				<Button
 					shape="square"
 					size="small"
 					variant="ghost"
@@ -65,7 +65,7 @@ function AutocompleteSingleValue() {
 					{...toggleBtnProps}
 				>
 					<ArrowDownIcon size={16} />
-				</NewButton>
+				</Button>
 			</Provider>
 		);
 	}, [overlayTriggerState?.isOpen, toggleBtnProps]);
@@ -101,7 +101,7 @@ function AutocompleteMultipleValue() {
 					[ButtonContext, { isPressed: overlayTriggerState?.isOpen }],
 				]}
 			>
-				<NewButton
+				<Button
 					shape="square"
 					size="small"
 					data-testid="trigger"
@@ -111,7 +111,7 @@ function AutocompleteMultipleValue() {
 					{...toggleBtnProps}
 				>
 					<ArrowDownIcon size={16} />
-				</NewButton>
+				</Button>
 			</Provider>
 		);
 	}, [overlayTriggerState?.isOpen, toggleBtnProps]);

--- a/_src/shared/ui/components/autocomplete/components/autocomplete-value.tsx
+++ b/_src/shared/ui/components/autocomplete/components/autocomplete-value.tsx
@@ -20,7 +20,7 @@ import {
 	FieldError,
 } from "react-aria-components";
 import { useAutocompleteValue } from "../hooks/use-autocomplete-value";
-import { ButtonSquare } from "../../button";
+import { NewButton } from "../../button";
 import { ArrowDownIcon, WarningIcon } from "../../icon";
 import { Chip, ChipGroup } from "../../chip";
 import { cva } from "class-variance-authority";
@@ -56,14 +56,16 @@ function AutocompleteSingleValue() {
 					[ButtonContext, { isPressed: overlayTriggerState?.isOpen }],
 				]}
 			>
-				<ButtonSquare
-					icon={ArrowDownIcon}
+				<NewButton
+					shape="square"
 					size="small"
 					variant="ghost"
 					aria-label="autocomplete-toggle-button"
 					excludeFromTabOrder={true}
 					{...toggleBtnProps}
-				/>
+				>
+					<ArrowDownIcon size={16} />
+				</NewButton>
 			</Provider>
 		);
 	}, [overlayTriggerState?.isOpen, toggleBtnProps]);
@@ -99,15 +101,17 @@ function AutocompleteMultipleValue() {
 					[ButtonContext, { isPressed: overlayTriggerState?.isOpen }],
 				]}
 			>
-				<ButtonSquare
-					icon={ArrowDownIcon}
+				<NewButton
+					shape="square"
 					size="small"
 					data-testid="trigger"
 					variant="ghost"
 					aria-label="autocomplete-toggle-button"
 					excludeFromTabOrder={true}
 					{...toggleBtnProps}
-				/>
+				>
+					<ArrowDownIcon size={16} />
+				</NewButton>
 			</Provider>
 		);
 	}, [overlayTriggerState?.isOpen, toggleBtnProps]);

--- a/_src/shared/ui/components/button/button.test.tsx
+++ b/_src/shared/ui/components/button/button.test.tsx
@@ -1,12 +1,12 @@
 import { test, describe, expect, vi } from "vitest";
 import { render } from "@/test/utilities";
 import { axe } from "jest-axe";
-import { Button, ButtonSquare } from "./component";
+import { NewButton } from "./component";
 import { CheckIcon } from "../icon";
 
-describe("Button", () => {
+describe("NewButton", () => {
 	test("renders correctly", async () => {
-		const wrapper = render(<Button title="Click me!" />);
+		const wrapper = render(<NewButton>Click me!</NewButton>);
 
 		expect(() => wrapper.unmount()).not.toThrow();
 	});
@@ -14,7 +14,7 @@ describe("Button", () => {
 	test("is pressable", async () => {
 		const onPressFn = vi.fn();
 		const { user, getByRole } = render(
-			<Button title="Click me!" onPress={onPressFn} />,
+			<NewButton onPress={onPressFn}>Click me!</NewButton>,
 		);
 		const button = getByRole("button");
 
@@ -26,7 +26,9 @@ describe("Button", () => {
 	test("isn't pressable when disabled", async () => {
 		const onPressFn = vi.fn();
 		const { user, getByRole } = render(
-			<Button title="Click me!" isDisabled onPress={onPressFn} />,
+			<NewButton isDisabled onPress={onPressFn}>
+				Click me!
+			</NewButton>,
 		);
 		const button = getByRole("button");
 
@@ -36,24 +38,28 @@ describe("Button", () => {
 	});
 
 	test("doesn't violate any accessiblity rules", async () => {
-		const { container } = render(<Button title="Click me!" />);
+		const { container } = render(<NewButton>Click me!</NewButton>);
 		const results = await axe(container);
 
 		expect(results).toHaveNoViolations();
 	});
-});
 
-describe("Button Square", () => {
-	test("renders correctly", async () => {
-		const wrapper = render(<ButtonSquare icon={CheckIcon} />);
+	test("renders square button correctly", async () => {
+		const wrapper = render(
+			<NewButton shape="square">
+				<CheckIcon size={18} />
+			</NewButton>,
+		);
 
 		expect(() => wrapper.unmount()).not.toThrow();
 	});
 
-	test("is pressable", async () => {
+	test("square button is pressable", async () => {
 		const onPressFn = vi.fn();
 		const { user, getByRole } = render(
-			<ButtonSquare icon={CheckIcon} onPress={onPressFn} />,
+			<NewButton shape="square" onPress={onPressFn}>
+				<CheckIcon size={18} />
+			</NewButton>,
 		);
 		const button = getByRole("button");
 
@@ -62,10 +68,12 @@ describe("Button Square", () => {
 		expect(onPressFn).toHaveBeenCalled();
 	});
 
-	test("isn't pressable when disabled", async () => {
+	test("square button isn't pressable when disabled", async () => {
 		const onPressFn = vi.fn();
 		const { user, getByRole } = render(
-			<ButtonSquare icon={CheckIcon} isDisabled onPress={onPressFn} />,
+			<NewButton shape="square" isDisabled onPress={onPressFn}>
+				<CheckIcon size={18} />
+			</NewButton>,
 		);
 		const button = getByRole("button");
 
@@ -74,14 +82,12 @@ describe("Button Square", () => {
 		expect(onPressFn).not.toHaveBeenCalled();
 	});
 
-	test("isn't pressable when isPending", async () => {
+	test("square button isn't pressable when isPending", async () => {
 		const onPressFn = vi.fn();
 		const { user, getByRole } = render(
-			<ButtonSquare
-				icon={CheckIcon}
-				isPending={true}
-				onPress={onPressFn}
-			/>,
+			<NewButton shape="square" isPending={true} onPress={onPressFn}>
+				<CheckIcon size={18} />
+			</NewButton>,
 		);
 		const button = getByRole("button");
 
@@ -90,8 +96,12 @@ describe("Button Square", () => {
 		expect(onPressFn).not.toHaveBeenCalled();
 	});
 
-	test("doesn't violate any accessiblity rules", async () => {
-		const { container } = render(<ButtonSquare icon={CheckIcon} />);
+	test("square button doesn't violate any accessiblity rules", async () => {
+		const { container } = render(
+			<NewButton shape="square">
+				<CheckIcon size={18} />
+			</NewButton>,
+		);
 		const results = await axe(container);
 
 		expect(results).toHaveNoViolations();

--- a/_src/shared/ui/components/button/button.test.tsx
+++ b/_src/shared/ui/components/button/button.test.tsx
@@ -1,12 +1,12 @@
 import { test, describe, expect, vi } from "vitest";
 import { render } from "@/test/utilities";
 import { axe } from "jest-axe";
-import { NewButton } from "./component";
+import { Button } from "./component";
 import { CheckIcon } from "../icon";
 
-describe("NewButton", () => {
+describe("Button", () => {
 	test("renders correctly", async () => {
-		const wrapper = render(<NewButton>Click me!</NewButton>);
+		const wrapper = render(<Button>Click me!</Button>);
 
 		expect(() => wrapper.unmount()).not.toThrow();
 	});
@@ -14,7 +14,7 @@ describe("NewButton", () => {
 	test("is pressable", async () => {
 		const onPressFn = vi.fn();
 		const { user, getByRole } = render(
-			<NewButton onPress={onPressFn}>Click me!</NewButton>,
+			<Button onPress={onPressFn}>Click me!</Button>,
 		);
 		const button = getByRole("button");
 
@@ -26,9 +26,9 @@ describe("NewButton", () => {
 	test("isn't pressable when disabled", async () => {
 		const onPressFn = vi.fn();
 		const { user, getByRole } = render(
-			<NewButton isDisabled onPress={onPressFn}>
+			<Button isDisabled onPress={onPressFn}>
 				Click me!
-			</NewButton>,
+			</Button>,
 		);
 		const button = getByRole("button");
 
@@ -38,7 +38,7 @@ describe("NewButton", () => {
 	});
 
 	test("doesn't violate any accessiblity rules", async () => {
-		const { container } = render(<NewButton>Click me!</NewButton>);
+		const { container } = render(<Button>Click me!</Button>);
 		const results = await axe(container);
 
 		expect(results).toHaveNoViolations();
@@ -46,9 +46,9 @@ describe("NewButton", () => {
 
 	test("renders square button correctly", async () => {
 		const wrapper = render(
-			<NewButton shape="square">
+			<Button shape="square">
 				<CheckIcon size={18} />
-			</NewButton>,
+			</Button>,
 		);
 
 		expect(() => wrapper.unmount()).not.toThrow();
@@ -57,9 +57,9 @@ describe("NewButton", () => {
 	test("square button is pressable", async () => {
 		const onPressFn = vi.fn();
 		const { user, getByRole } = render(
-			<NewButton shape="square" onPress={onPressFn}>
+			<Button shape="square" onPress={onPressFn}>
 				<CheckIcon size={18} />
-			</NewButton>,
+			</Button>,
 		);
 		const button = getByRole("button");
 
@@ -71,9 +71,9 @@ describe("NewButton", () => {
 	test("square button isn't pressable when disabled", async () => {
 		const onPressFn = vi.fn();
 		const { user, getByRole } = render(
-			<NewButton shape="square" isDisabled onPress={onPressFn}>
+			<Button shape="square" isDisabled onPress={onPressFn}>
 				<CheckIcon size={18} />
-			</NewButton>,
+			</Button>,
 		);
 		const button = getByRole("button");
 
@@ -85,9 +85,9 @@ describe("NewButton", () => {
 	test("square button isn't pressable when isPending", async () => {
 		const onPressFn = vi.fn();
 		const { user, getByRole } = render(
-			<NewButton shape="square" isPending={true} onPress={onPressFn}>
+			<Button shape="square" isPending={true} onPress={onPressFn}>
 				<CheckIcon size={18} />
-			</NewButton>,
+			</Button>,
 		);
 		const button = getByRole("button");
 
@@ -98,9 +98,9 @@ describe("NewButton", () => {
 
 	test("square button doesn't violate any accessiblity rules", async () => {
 		const { container } = render(
-			<NewButton shape="square">
+			<Button shape="square">
 				<CheckIcon size={18} />
-			</NewButton>,
+			</Button>,
 		);
 		const results = await axe(container);
 

--- a/_src/shared/ui/components/button/component.tsx
+++ b/_src/shared/ui/components/button/component.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { forwardRef, HTMLAttributes, ReactNode } from "react";
-import { IconType } from "../icon/icon-builder";
 import {
 	ButtonContext,
 	ButtonProps,
@@ -15,88 +14,6 @@ import {
 } from "../../styles/button.styles";
 import { cva } from "class-variance-authority";
 
-type BaseButtonProps = { isPending?: boolean } & ButtonStylesProps &
-	ButtonProps &
-	HTMLAttributes<HTMLButtonElement>;
-
-export type LabeledButtonProps = BaseButtonProps & {
-	title: string;
-	contentLeft?: ReactNode;
-	contentRight?: ReactNode;
-};
-
-type SquareButtonProps = BaseButtonProps & { icon: IconType };
-
-export const Button = forwardRef<HTMLButtonElement, LabeledButtonProps>(
-	(props, ref) => {
-		[props, ref] = useContextProps(props, ref, ButtonContext);
-		const {
-			title,
-			size = "medium",
-			variant = "default",
-			appearance = "primary",
-			isPending = false,
-			contentLeft,
-			contentRight,
-			role,
-			className,
-		} = props;
-
-		const { buttonProps, isPressed } = useButton(
-			{
-				...props,
-				isDisabled: props.isDisabled || isPending,
-			},
-			ref,
-		);
-		const { hoverProps, isHovered } = useHover({
-			...props,
-			isDisabled: props.isDisabled || isPending,
-		});
-		const { focusProps, isFocused, isFocusVisible } = useFocusRing(props);
-
-		return (
-			<button
-				style={COLOR_SCHEMES[appearance] as React.CSSProperties}
-				className={twMerge(
-					buttonStyles({
-						size,
-						variant,
-						form: "default",
-						excludeFromFocus: props.excludeFromTabOrder,
-						// we need to get the ButtonContextValue from the context, but for some reason it's not exposed for public usage
-						isPressed:
-							isPressed ||
-							(
-								props as LabeledButtonProps & {
-									isPressed?: boolean;
-								}
-							).isPressed,
-						isFocused: isFocusVisible,
-						isHovered,
-						isDisabled: props.isDisabled || isPending,
-					}),
-					className,
-				)}
-				ref={ref}
-				role={role || "button"}
-				data-focused={isFocused || undefined}
-				aria-label={buttonProps["aria-label"] || "icon button"}
-				{...mergeProps(buttonProps, focusProps, hoverProps)}
-			>
-				<div className={spinnerStyles({ isActive: isPending })}>
-					<div>
-						<div className="border-r-primary-500 animate-rotation-linear aspect-square w-4 rounded-full border-2 border-y-neutral-200 border-l-neutral-200" />
-					</div>
-				</div>
-				{contentLeft}
-				{title}
-				{contentRight}
-			</button>
-		);
-	},
-);
-
 const spinnerStyles = cva("flex justify-center items-center", {
 	variants: {
 		isActive: {
@@ -106,86 +23,7 @@ const spinnerStyles = cva("flex justify-center items-center", {
 	},
 });
 
-export const ButtonSquare = forwardRef<HTMLButtonElement, SquareButtonProps>(
-	(props, ref) => {
-		[props, ref] = useContextProps(props, ref, ButtonContext);
-		const {
-			size = "medium",
-			variant = "default",
-			appearance = "primary",
-			isPending = false,
-			icon,
-			role,
-			className,
-			style,
-		} = props;
-
-		const { buttonProps, isPressed: isPressedLocal } = useButton(
-			{
-				...props,
-				isDisabled: props.isDisabled || isPending,
-			},
-			ref,
-		);
-		const { hoverProps, isHovered } = useHover({
-			...props,
-			isDisabled: props.isDisabled || isPending,
-		});
-		const { focusProps, isFocused, isFocusVisible } = useFocusRing(props);
-
-		const isPressed =
-			isPressedLocal ||
-			(
-				props as SquareButtonProps & {
-					isPressed?: boolean;
-				}
-			).isPressed;
-
-		return (
-			<button
-				className={twMerge(
-					buttonStyles({
-						size,
-						variant,
-						form: "square",
-						// we need to get the ButtonContextValue from the context, but for some reason it's not exposed for public usage
-						isPressed,
-						excludeFromFocus: props.excludeFromTabOrder,
-						isFocused: isFocusVisible,
-						isHovered,
-						isDisabled: props.isDisabled || isPending,
-					}),
-					className,
-				)}
-				ref={ref}
-				aria-label={buttonProps["aria-label"] || "icon button"}
-				data-focused={isFocused || undefined}
-				data-pressed={isPressed}
-				role={role || "button"}
-				style={{
-					...(COLOR_SCHEMES[appearance] as React.CSSProperties),
-					...style,
-				}}
-				{...mergeProps(buttonProps, focusProps, hoverProps)}
-			>
-				<div className={spinnerStyles({ isActive: isPending })}>
-					<div>
-						<div className="border-r-primary-500 animate-rotation-linear aspect-square w-6 rounded-full border-4 border-neutral-200" />
-					</div>
-				</div>
-				{!isPending && icon({ size: ButtonIconSize[size] })}
-			</button>
-		);
-	},
-);
-
-const ButtonIconSize = {
-	small: 16,
-	medium: 18,
-	large: 24,
-};
-
-type NewButtonProps = {
+type ButtonComponentProps = {
 	isPending?: boolean;
 	children: ReactNode;
 	shape?: "default" | "square";
@@ -193,7 +31,7 @@ type NewButtonProps = {
 	ButtonProps &
 	HTMLAttributes<HTMLButtonElement>;
 
-export const NewButton = forwardRef<HTMLButtonElement, NewButtonProps>(
+export const Button = forwardRef<HTMLButtonElement, ButtonComponentProps>(
 	(props, ref) => {
 		[props, ref] = useContextProps(props, ref, ButtonContext);
 		const {
@@ -233,7 +71,7 @@ export const NewButton = forwardRef<HTMLButtonElement, NewButtonProps>(
 						isPressed:
 							isPressed ||
 							(
-								props as LabeledButtonProps & {
+								props as ButtonComponentProps & {
 									isPressed?: boolean;
 								}
 							).isPressed,

--- a/_src/shared/ui/components/button/component.tsx
+++ b/_src/shared/ui/components/button/component.tsx
@@ -58,6 +58,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonComponentProps>(
 		});
 		const { focusProps, isFocused, isFocusVisible } = useFocusRing(props);
 
+		const isChildrenVisible = !(isPending && shape === "square");
+
 		return (
 			<button
 				style={COLOR_SCHEMES[appearance] as React.CSSProperties}
@@ -92,7 +94,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonComponentProps>(
 						<div className="border-r-primary-500 animate-rotation-linear aspect-square w-4 rounded-full border-2 border-y-neutral-200 border-l-neutral-200" />
 					</div>
 				</div>
-				{children}
+				{isChildrenVisible && children}
 			</button>
 		);
 	},

--- a/_src/shared/ui/components/button/index.ts
+++ b/_src/shared/ui/components/button/index.ts
@@ -1,3 +1,2 @@
 "use client";
-export { Button, ButtonSquare, NewButton } from "./component";
-export type { LabeledButtonProps } from "./component";
+export { Button } from "./component";

--- a/_src/shared/ui/components/cookie-consent/component.tsx
+++ b/_src/shared/ui/components/cookie-consent/component.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { ConsentStatus, useCookieConsentState } from "@/_src/shared/providers";
 import { NextLink } from "../../next-components/next-link";
-import { NewButton } from "../button";
+import { Button } from "../button";
 
 export function CookieConsent() {
 	const { consentStatus, giveConsent, rejectConsent } =
@@ -24,10 +24,10 @@ export function CookieConsent() {
 			</div>
 
 			<div className="flex flex-row justify-end gap-4">
-				<NewButton onPress={giveConsent}>Accept All Cookeis</NewButton>
-				<NewButton variant="ghost" onPress={rejectConsent}>
+				<Button onPress={giveConsent}>Accept All Cookeis</Button>
+				<Button variant="ghost" onPress={rejectConsent}>
 					Reject
-				</NewButton>
+				</Button>
 			</div>
 		</div>
 	);

--- a/_src/shared/ui/components/error-boundary/component.tsx
+++ b/_src/shared/ui/components/error-boundary/component.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { ErrorBoundary, FallbackProps } from "react-error-boundary";
-import { NewButton } from "../button";
+import { Button } from "../button";
 import { RefreshBorderlessIcon } from "../icon/svg/refresh-borderless.icon";
 import { ReactNode } from "react";
 import { logger } from "@/_src/shared/lib";
@@ -24,14 +24,14 @@ export function InternalErrorBoundary(props: InternalErrorBoundaryProps) {
 							<p className="text-sm">Something went wrong...</p>
 						</div>
 
-						<NewButton
+						<Button
 							onPress={props.resetErrorBoundary}
 							size="small"
 							variant="grayed-out"
 						>
 							<RefreshBorderlessIcon size={14} />
 							Try again
-						</NewButton>
+						</Button>
 					</div>
 				);
 			}}

--- a/_src/shared/ui/components/inline-edit/component.tsx
+++ b/_src/shared/ui/components/inline-edit/component.tsx
@@ -1,9 +1,9 @@
 import { ReactNode, useId, useMemo } from "react";
 import { useOverlayTriggerState } from "react-stately";
-import { NewButton } from "../button";
+import { Button } from "../button";
 import { CheckIcon, CloseIcon } from "../icon";
 import { PopoverWithoutFocusManagment } from "./components/popover-without-focus-management";
-import { Button, Label } from "react-aria-components";
+import { Button as AriaButton, Label } from "react-aria-components";
 import { useInlineEditState } from "./state/use-inline-edit-state";
 import { useInlineEdit } from "./behavior/use-inline-edit";
 import { twMerge } from "tailwind-merge";
@@ -71,7 +71,7 @@ export const InlineEdit = (props: InlineEditProps) => {
 	const actionButtons = useMemo(() => {
 		return (
 			<div className="flex flex-row gap-1">
-				<NewButton
+				<Button
 					shape="square"
 					variant={keepEditViewOpenOnBlur ? "outline" : "grayed-out"}
 					className={actionBtnStyles({
@@ -81,8 +81,8 @@ export const InlineEdit = (props: InlineEditProps) => {
 					{...confirmBtnProps}
 				>
 					<CheckIcon size={18} />
-				</NewButton>
-				<NewButton
+				</Button>
+				<Button
 					shape="square"
 					variant={keepEditViewOpenOnBlur ? "outline" : "grayed-out"}
 					className={actionBtnStyles({
@@ -92,7 +92,7 @@ export const InlineEdit = (props: InlineEditProps) => {
 					{...cancelBtnProps}
 				>
 					<CloseIcon size={18} />
-				</NewButton>
+				</Button>
 			</div>
 		);
 	}, [confirmBtnProps, cancelBtnProps, id, keepEditViewOpenOnBlur]);
@@ -109,14 +109,14 @@ export const InlineEdit = (props: InlineEditProps) => {
 					</Label>
 				)}
 				{!overlayTriggerState.isOpen && (
-					<Button
+					<AriaButton
 						onPress={overlayTriggerState.open}
 						className="outline-primary-500 rounded-lg text-left"
 						isDisabled={isDisabled}
 						data-testid={`${id}-read-view`}
 					>
 						{readView({ value: state.editorValue })}
-					</Button>
+					</AriaButton>
 				)}
 				{overlayTriggerState.isOpen &&
 					!isDisabled &&

--- a/_src/shared/ui/components/inline-edit/component.tsx
+++ b/_src/shared/ui/components/inline-edit/component.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useId, useMemo } from "react";
 import { useOverlayTriggerState } from "react-stately";
-import { ButtonSquare } from "../button";
+import { NewButton } from "../button";
 import { CheckIcon, CloseIcon } from "../icon";
 import { PopoverWithoutFocusManagment } from "./components/popover-without-focus-management";
 import { Button, Label } from "react-aria-components";
@@ -71,24 +71,28 @@ export const InlineEdit = (props: InlineEditProps) => {
 	const actionButtons = useMemo(() => {
 		return (
 			<div className="flex flex-row gap-1">
-				<ButtonSquare
+				<NewButton
+					shape="square"
 					variant={keepEditViewOpenOnBlur ? "outline" : "grayed-out"}
 					className={actionBtnStyles({
 						withShadow: !keepEditViewOpenOnBlur,
 					})}
-					icon={CheckIcon}
 					data-testid={`${id}-confirm-button`}
 					{...confirmBtnProps}
-				/>
-				<ButtonSquare
+				>
+					<CheckIcon size={18} />
+				</NewButton>
+				<NewButton
+					shape="square"
 					variant={keepEditViewOpenOnBlur ? "outline" : "grayed-out"}
 					className={actionBtnStyles({
 						withShadow: !keepEditViewOpenOnBlur,
 					})}
 					data-testid={`${id}-cancel-button`}
-					icon={CloseIcon}
 					{...cancelBtnProps}
-				/>
+				>
+					<CloseIcon size={18} />
+				</NewButton>
 			</div>
 		);
 	}, [confirmBtnProps, cancelBtnProps, id, keepEditViewOpenOnBlur]);

--- a/_src/shared/ui/components/input/input.test.tsx
+++ b/_src/shared/ui/components/input/input.test.tsx
@@ -3,7 +3,7 @@ import { Input } from "./component";
 import { render } from "@/test/utilities";
 import { axe } from "jest-axe";
 import { PeopleIcon } from "../icon";
-import { ButtonSquare } from "../button";
+import { NewButton } from "../button";
 
 describe("Input (Text Field)", () => {
 	test("renders correctly", () => {
@@ -58,7 +58,9 @@ describe("Input (Text Field)", () => {
 			<Input
 				label="Label"
 				endContent={
-					<ButtonSquare icon={PeopleIcon} onPress={onButtonPressFn} />
+					<NewButton shape="square" onPress={onButtonPressFn}>
+						<PeopleIcon size={18} />
+					</NewButton>
 				}
 			/>,
 		);

--- a/_src/shared/ui/components/input/input.test.tsx
+++ b/_src/shared/ui/components/input/input.test.tsx
@@ -3,7 +3,7 @@ import { Input } from "./component";
 import { render } from "@/test/utilities";
 import { axe } from "jest-axe";
 import { PeopleIcon } from "../icon";
-import { NewButton } from "../button";
+import { Button } from "../button";
 
 describe("Input (Text Field)", () => {
 	test("renders correctly", () => {
@@ -58,9 +58,9 @@ describe("Input (Text Field)", () => {
 			<Input
 				label="Label"
 				endContent={
-					<NewButton shape="square" onPress={onButtonPressFn}>
+					<Button shape="square" onPress={onButtonPressFn}>
 						<PeopleIcon size={18} />
-					</NewButton>
+					</Button>
 				}
 			/>,
 		);

--- a/_src/shared/ui/components/menu/menu.test.tsx
+++ b/_src/shared/ui/components/menu/menu.test.tsx
@@ -2,13 +2,15 @@ import { test, describe, expect } from "vitest";
 import { render } from "@/test/utilities";
 import { axe } from "jest-axe";
 import { Menu } from "./component";
-import { ButtonSquare } from "../button";
+import { NewButton } from "../button";
 import { CardsIcon, PeopleIcon, SettingsIcon } from "../icon";
 
 function renderMenu() {
 	return render(
 		<Menu>
-			<ButtonSquare icon={SettingsIcon} />
+			<NewButton shape="square">
+				<SettingsIcon size={18} />
+			</NewButton>
 			<Menu.Content>
 				<Menu.Section title="Dropdown Title">
 					<Menu.Item id={1}>

--- a/_src/shared/ui/components/menu/menu.test.tsx
+++ b/_src/shared/ui/components/menu/menu.test.tsx
@@ -2,15 +2,15 @@ import { test, describe, expect } from "vitest";
 import { render } from "@/test/utilities";
 import { axe } from "jest-axe";
 import { Menu } from "./component";
-import { NewButton } from "../button";
+import { Button } from "../button";
 import { CardsIcon, PeopleIcon, SettingsIcon } from "../icon";
 
 function renderMenu() {
 	return render(
 		<Menu>
-			<NewButton shape="square">
+			<Button shape="square">
 				<SettingsIcon size={18} />
-			</NewButton>
+			</Button>
 			<Menu.Content>
 				<Menu.Section title="Dropdown Title">
 					<Menu.Item id={1}>

--- a/_src/shared/ui/components/modals/confirmation-modal.tsx
+++ b/_src/shared/ui/components/modals/confirmation-modal.tsx
@@ -1,11 +1,8 @@
-import {
-	Button,
-	LabeledButtonProps,
-	NewButton,
-} from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { CloseIcon } from "@/_src/shared/ui/components/icon/svg/close.icon";
 import { Modal } from "@/_src/shared/ui/components/modal";
 import { useCallback, useTransition } from "react";
+import type { ButtonStylesProps } from "@/_src/shared/ui/styles/button.styles";
 
 type SyncConfirm = () => void;
 type AsyncConfirm = () => Promise<void>;
@@ -13,7 +10,7 @@ export type ConfirmationModalState = {
 	title: string;
 	contentMessage: string;
 	confirmBtnText: string;
-	confirmBtnAppearence?: LabeledButtonProps["appearance"];
+	confirmBtnAppearence?: ButtonStylesProps["appearance"];
 	onConfirm: AsyncConfirm | SyncConfirm;
 };
 export type ConfirmationModalProps = {
@@ -47,14 +44,14 @@ export function ConfirmationModal({
 				{({ close }) => (
 					<>
 						<Modal.Title>{state?.title}</Modal.Title>
-						<NewButton
+						<Button
 							variant="ghost"
 							shape="square"
 							data-testid="dismiss-button"
 							onPress={close}
 						>
 							<CloseIcon className="w-8 h-8" />
-						</NewButton>
+						</Button>
 					</>
 				)}
 			</Modal.Header>
@@ -63,18 +60,20 @@ export function ConfirmationModal({
 				{({ close }) => (
 					<>
 						<Button
-							title="Cancel"
 							onPress={close}
 							data-testid="cancel-button"
 							variant="ghost"
-						/>
+						>
+							Cancel
+						</Button>
 						<Button
-							title={state?.confirmBtnText || ""}
 							isPending={isPending}
 							onPress={confirm}
 							data-testid="confirm-button"
 							appearance={state?.confirmBtnAppearence}
-						/>
+						>
+							{state?.confirmBtnText || ""}
+						</Button>
 					</>
 				)}
 			</Modal.Footer>

--- a/_src/shared/ui/components/onboarding/onboarding-step.tsx
+++ b/_src/shared/ui/components/onboarding/onboarding-step.tsx
@@ -2,7 +2,7 @@ import { cloneElement, ReactElement, useEffect, useRef } from "react";
 import throttle from "lodash.throttle";
 import { Dialog, Heading, ModalOverlay, Popover } from "react-aria-components";
 import { twMerge } from "tailwind-merge";
-import { NewButton } from "../button";
+import { Button } from "../button";
 import { OnboardingState, useOnboardingState } from "./use-onboarding-state";
 import { useOnboardingActions } from "./use-onboarding-actions";
 import { Placement } from "react-aria";
@@ -172,21 +172,21 @@ function OnboardingStepInner({
 								</span>
 								<div className="flex flex-row gap-2">
 									{!isLastStep && (
-										<NewButton
+										<Button
 											onPress={onDismissPressed}
 											variant="ghost"
 											size="small"
 											className="text-white"
 										>
 											Dismiss
-										</NewButton>
+										</Button>
 									)}
-									<NewButton
+									<Button
 										onPress={onNextPressed}
 										size="small"
 									>
 										{isLastStep ? "Done" : "Next"}
-									</NewButton>
+									</Button>
 								</div>
 							</div>
 						</div>

--- a/_src/shared/ui/components/popover/popover.test.tsx
+++ b/_src/shared/ui/components/popover/popover.test.tsx
@@ -5,14 +5,14 @@ import { test, describe, expect } from "vitest";
 import { render } from "@/test/utilities";
 import { axe } from "jest-axe";
 import { Popover } from "./component";
-import { Button, ButtonSquare } from "../button";
+import { NewButton } from "../button";
 import { CloseIcon } from "../icon";
 
 describe("Popover", () => {
 	test("renders correctly", async () => {
 		const { unmount } = render(
 			<Popover>
-				<Button title="Click" />
+				<NewButton>Click</NewButton>
 				<Popover.Content>Popover Content</Popover.Content>
 			</Popover>,
 		);
@@ -23,7 +23,7 @@ describe("Popover", () => {
 	test("opens and closes on overlay/trigger click", async () => {
 		const { user, getByRole, queryByText, getByText, container } = render(
 			<Popover>
-				<Button title="Click" role="trigger" />
+				<NewButton role="trigger">Click</NewButton>
 				<Popover.Content>Popover Content</Popover.Content>
 			</Popover>,
 		);
@@ -50,7 +50,7 @@ describe("Popover", () => {
 	test("doesn't close on content click", async () => {
 		const { user, getByRole, queryByText, getByText } = render(
 			<Popover>
-				<Button title="Click" role="trigger" />
+				<NewButton role="trigger">Click</NewButton>
 				<Popover.Content>Popover Content</Popover.Content>
 			</Popover>,
 		);
@@ -66,16 +66,18 @@ describe("Popover", () => {
 	test("closes on button with slot=close", async () => {
 		const { user, getByRole, queryByText } = render(
 			<Popover>
-				<Button title="Click" role="trigger" />
+				<NewButton role="trigger">Click</NewButton>
 				<Popover.Content>
 					<div>
 						<p>Popover Content</p>
-						<ButtonSquare
+						<NewButton
+							shape="square"
 							size="small"
-							icon={CloseIcon}
 							slot="close"
 							role="close-button"
-						/>
+						>
+							<CloseIcon size={16} />
+						</NewButton>
 					</div>
 					Popover Content
 				</Popover.Content>
@@ -92,7 +94,7 @@ describe("Popover", () => {
 	test("doesn't violate any accessiblity rules", async () => {
 		const { container } = render(
 			<Popover>
-				<Button title="Click" />
+				<NewButton>Click</NewButton>
 				<Popover.Content>Popover Content</Popover.Content>
 			</Popover>,
 		);

--- a/_src/shared/ui/components/popover/popover.test.tsx
+++ b/_src/shared/ui/components/popover/popover.test.tsx
@@ -5,14 +5,14 @@ import { test, describe, expect } from "vitest";
 import { render } from "@/test/utilities";
 import { axe } from "jest-axe";
 import { Popover } from "./component";
-import { NewButton } from "../button";
+import { Button } from "../button";
 import { CloseIcon } from "../icon";
 
 describe("Popover", () => {
 	test("renders correctly", async () => {
 		const { unmount } = render(
 			<Popover>
-				<NewButton>Click</NewButton>
+				<Button>Click</Button>
 				<Popover.Content>Popover Content</Popover.Content>
 			</Popover>,
 		);
@@ -23,7 +23,7 @@ describe("Popover", () => {
 	test("opens and closes on overlay/trigger click", async () => {
 		const { user, getByRole, queryByText, getByText, container } = render(
 			<Popover>
-				<NewButton role="trigger">Click</NewButton>
+				<Button role="trigger">Click</Button>
 				<Popover.Content>Popover Content</Popover.Content>
 			</Popover>,
 		);
@@ -50,7 +50,7 @@ describe("Popover", () => {
 	test("doesn't close on content click", async () => {
 		const { user, getByRole, queryByText, getByText } = render(
 			<Popover>
-				<NewButton role="trigger">Click</NewButton>
+				<Button role="trigger">Click</Button>
 				<Popover.Content>Popover Content</Popover.Content>
 			</Popover>,
 		);
@@ -66,18 +66,18 @@ describe("Popover", () => {
 	test("closes on button with slot=close", async () => {
 		const { user, getByRole, queryByText } = render(
 			<Popover>
-				<NewButton role="trigger">Click</NewButton>
+				<Button role="trigger">Click</Button>
 				<Popover.Content>
 					<div>
 						<p>Popover Content</p>
-						<NewButton
+						<Button
 							shape="square"
 							size="small"
 							slot="close"
 							role="close-button"
 						>
 							<CloseIcon size={16} />
-						</NewButton>
+						</Button>
 					</div>
 					Popover Content
 				</Popover.Content>
@@ -94,7 +94,7 @@ describe("Popover", () => {
 	test("doesn't violate any accessiblity rules", async () => {
 		const { container } = render(
 			<Popover>
-				<NewButton>Click</NewButton>
+				<Button>Click</Button>
 				<Popover.Content>Popover Content</Popover.Content>
 			</Popover>,
 		);

--- a/_src/shared/ui/components/toast/components/toast.tsx
+++ b/_src/shared/ui/components/toast/components/toast.tsx
@@ -3,7 +3,7 @@ import { ToastState } from "@react-stately/toast";
 import { AriaToastProps, useToast } from "@react-aria/toast";
 
 import { ToastContent } from "../models/toast-content";
-import { ButtonSquare } from "../../button";
+import { NewButton } from "../../button";
 import { InfoIcon } from "../../icon/svg/info.icon";
 import { ErrorIcon } from "../../icon/svg/error.icon";
 import { CloseIcon } from "../../icon/svg/close.icon";
@@ -53,13 +53,15 @@ export function Toast(props: ToastProps) {
 						</p>
 					</div>
 				</div>
-				<ButtonSquare
+				<NewButton
+					shape="square"
 					className="absolute top-2 right-2 text-neutral-900"
 					variant="ghost"
 					size="small"
-					icon={CloseIcon}
 					{...closeButtonProps}
-				/>
+				>
+					<CloseIcon size={16} />
+				</NewButton>
 			</div>
 		</div>
 	);

--- a/_src/shared/ui/components/toast/components/toast.tsx
+++ b/_src/shared/ui/components/toast/components/toast.tsx
@@ -3,7 +3,7 @@ import { ToastState } from "@react-stately/toast";
 import { AriaToastProps, useToast } from "@react-aria/toast";
 
 import { ToastContent } from "../models/toast-content";
-import { NewButton } from "../../button";
+import { Button } from "../../button";
 import { InfoIcon } from "../../icon/svg/info.icon";
 import { ErrorIcon } from "../../icon/svg/error.icon";
 import { CloseIcon } from "../../icon/svg/close.icon";
@@ -53,7 +53,7 @@ export function Toast(props: ToastProps) {
 						</p>
 					</div>
 				</div>
-				<NewButton
+				<Button
 					shape="square"
 					className="absolute top-2 right-2 text-neutral-900"
 					variant="ghost"
@@ -61,7 +61,7 @@ export function Toast(props: ToastProps) {
 					{...closeButtonProps}
 				>
 					<CloseIcon size={16} />
-				</NewButton>
+				</Button>
 			</div>
 		</div>
 	);

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -41,15 +41,19 @@ export default function Error({
 				<Button
 					title="Go Back"
 					variant="ghost"
-					contentLeft={ArrowLeftIcon({ size: 18 })}
+					shape="square"
 					onPress={() => router.back()}
-				/>
+				>
+					<ArrowLeftIcon size={18} />
+				</Button>
 				<Button
 					title="Try Again"
 					variant="outline"
-					contentLeft={RefreshBorderlessIcon({ size: 18 })}
+					shape="square"
 					onPress={reset}
-				/>
+				>
+					<RefreshBorderlessIcon size={18} />
+				</Button>
 			</div>
 		</div>
 	);

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -38,21 +38,13 @@ export default function Error({
 				😔👉👈
 			</div>
 			<div className="flex flex-row gap-2">
-				<Button
-					title="Go Back"
-					variant="ghost"
-					shape="square"
-					onPress={() => router.back()}
-				>
+				<Button variant="ghost" onPress={() => router.back()}>
 					<ArrowLeftIcon size={18} />
+					Go Back
 				</Button>
-				<Button
-					title="Try Again"
-					variant="outline"
-					shape="square"
-					onPress={reset}
-				>
+				<Button variant="outline" onPress={reset}>
 					<RefreshBorderlessIcon size={18} />
+					Try Again
 				</Button>
 			</div>
 		</div>

--- a/stories/shared/Button.stories.tsx
+++ b/stories/shared/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { ArrowRightIcon, SettingsIcon } from "@/_src/shared/ui/components/icon";
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { fn, within, expect } from "storybook/test";
@@ -6,23 +6,23 @@ import { useState } from "react";
 
 const meta = {
 	title: "Shared/Button",
-	component: Button,
+	component: NewButton,
 	parameters: {
 		layout: "centered",
 	},
 	tags: ["autodocs"],
 	argTypes: {},
 	args: { onPress: fn() },
-} satisfies Meta<typeof Button>;
+} satisfies Meta<typeof NewButton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 const Default: Story = {
 	args: {
-		title: "Button",
-		form: "default",
+		children: "Button",
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const DefaultLargeDisabled: Story = {
@@ -30,9 +30,14 @@ export const DefaultLargeDisabled: Story = {
 		...Default.args,
 		size: "large",
 		isDisabled: true,
-		contentLeft: SettingsIcon({ size: 18 }),
-		contentRight: ArrowRightIcon({ size: 18 }),
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={18} />
+			Button
+			<ArrowRightIcon size={18} />
+		</NewButton>
+	),
 };
 
 export const DefaultLargePending: Story = {
@@ -40,9 +45,14 @@ export const DefaultLargePending: Story = {
 		...Default.args,
 		size: "large",
 		isPending: true,
-		contentLeft: SettingsIcon({ size: 18 }),
-		contentRight: ArrowRightIcon({ size: 18 }),
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={18} />
+			Button
+			<ArrowRightIcon size={18} />
+		</NewButton>
+	),
 };
 
 export const DefaultLarge: Story = {
@@ -50,6 +60,7 @@ export const DefaultLarge: Story = {
 		...Default.args,
 		size: "large",
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const button = canvas.getByRole("button");
@@ -64,19 +75,20 @@ export const DefaultMedium: Story = {
 		...Default.args,
 		size: "medium",
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const DefaultMediumPending = () => {
 	const [isPending, setIsPending] = useState(false);
 	return (
-		<Button
-			title="Button"
-			form="default"
+		<NewButton
 			size="medium"
 			appearance="danger"
 			isPending={isPending}
 			onPress={() => setIsPending(true)}
-		/>
+		>
+			Button
+		</NewButton>
 	);
 };
 
@@ -85,6 +97,7 @@ export const DefaultSmall: Story = {
 		...Default.args,
 		size: "small",
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const OutlineLargeDisabled: Story = {
@@ -94,6 +107,7 @@ export const OutlineLargeDisabled: Story = {
 		variant: "outline",
 		isDisabled: true,
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const OutlineLarge: Story = {
@@ -101,8 +115,13 @@ export const OutlineLarge: Story = {
 		...Default.args,
 		size: "large",
 		variant: "outline",
-		contentLeft: SettingsIcon({ size: 18 }),
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={18} />
+			Button
+		</NewButton>
+	),
 };
 
 export const OutlineMedium: Story = {
@@ -111,6 +130,7 @@ export const OutlineMedium: Story = {
 		size: "medium",
 		variant: "outline",
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const OutlineMediumPending: Story = {
@@ -120,6 +140,7 @@ export const OutlineMediumPending: Story = {
 		variant: "outline",
 		isPending: true,
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const OutlineSmall: Story = {
@@ -128,6 +149,7 @@ export const OutlineSmall: Story = {
 		size: "small",
 		variant: "outline",
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const GhostLargeDisabled: Story = {
@@ -137,6 +159,7 @@ export const GhostLargeDisabled: Story = {
 		variant: "ghost",
 		isDisabled: true,
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const GhostLarge: Story = {
@@ -145,6 +168,7 @@ export const GhostLarge: Story = {
 		size: "large",
 		variant: "ghost",
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const GhostMedium: Story = {
@@ -153,6 +177,7 @@ export const GhostMedium: Story = {
 		size: "medium",
 		variant: "ghost",
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const GhostMediumPending: Story = {
@@ -162,6 +187,7 @@ export const GhostMediumPending: Story = {
 		variant: "ghost",
 		isPending: true,
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const GhostSmall: Story = {
@@ -170,6 +196,7 @@ export const GhostSmall: Story = {
 		size: "small",
 		variant: "ghost",
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const GrayedOutLargeDisabled: Story = {
@@ -179,6 +206,7 @@ export const GrayedOutLargeDisabled: Story = {
 		variant: "grayed-out",
 		isDisabled: true,
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const GrayedOutLarge: Story = {
@@ -186,8 +214,13 @@ export const GrayedOutLarge: Story = {
 		...Default.args,
 		size: "large",
 		variant: "grayed-out",
-		contentRight: ArrowRightIcon({ size: 18 }),
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			Button
+			<ArrowRightIcon size={18} />
+		</NewButton>
+	),
 };
 
 export const GrayedOutMedium: Story = {
@@ -196,6 +229,7 @@ export const GrayedOutMedium: Story = {
 		size: "medium",
 		variant: "grayed-out",
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const GrayedOutMediumPending: Story = {
@@ -205,6 +239,7 @@ export const GrayedOutMediumPending: Story = {
 		variant: "grayed-out",
 		isPending: true,
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };
 
 export const GrayedOutSmall: Story = {
@@ -213,4 +248,5 @@ export const GrayedOutSmall: Story = {
 		size: "small",
 		variant: "grayed-out",
 	},
+	render: (args) => <NewButton {...args}>Button</NewButton>,
 };

--- a/stories/shared/Button.stories.tsx
+++ b/stories/shared/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { ArrowRightIcon, SettingsIcon } from "@/_src/shared/ui/components/icon";
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { fn, within, expect } from "storybook/test";
@@ -6,14 +6,14 @@ import { useState } from "react";
 
 const meta = {
 	title: "Shared/Button",
-	component: NewButton,
+	component: Button,
 	parameters: {
 		layout: "centered",
 	},
 	tags: ["autodocs"],
 	argTypes: {},
 	args: { onPress: fn() },
-} satisfies Meta<typeof NewButton>;
+} satisfies Meta<typeof Button>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -22,7 +22,7 @@ const Default: Story = {
 	args: {
 		children: "Button",
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const DefaultLargeDisabled: Story = {
@@ -32,11 +32,11 @@ export const DefaultLargeDisabled: Story = {
 		isDisabled: true,
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={18} />
 			Button
 			<ArrowRightIcon size={18} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -47,11 +47,11 @@ export const DefaultLargePending: Story = {
 		isPending: true,
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={18} />
 			Button
 			<ArrowRightIcon size={18} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -60,7 +60,7 @@ export const DefaultLarge: Story = {
 		...Default.args,
 		size: "large",
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const button = canvas.getByRole("button");
@@ -75,20 +75,20 @@ export const DefaultMedium: Story = {
 		...Default.args,
 		size: "medium",
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const DefaultMediumPending = () => {
 	const [isPending, setIsPending] = useState(false);
 	return (
-		<NewButton
+		<Button
 			size="medium"
 			appearance="danger"
 			isPending={isPending}
 			onPress={() => setIsPending(true)}
 		>
 			Button
-		</NewButton>
+		</Button>
 	);
 };
 
@@ -97,7 +97,7 @@ export const DefaultSmall: Story = {
 		...Default.args,
 		size: "small",
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const OutlineLargeDisabled: Story = {
@@ -107,7 +107,7 @@ export const OutlineLargeDisabled: Story = {
 		variant: "outline",
 		isDisabled: true,
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const OutlineLarge: Story = {
@@ -117,10 +117,10 @@ export const OutlineLarge: Story = {
 		variant: "outline",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={18} />
 			Button
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -130,7 +130,7 @@ export const OutlineMedium: Story = {
 		size: "medium",
 		variant: "outline",
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const OutlineMediumPending: Story = {
@@ -140,7 +140,7 @@ export const OutlineMediumPending: Story = {
 		variant: "outline",
 		isPending: true,
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const OutlineSmall: Story = {
@@ -149,7 +149,7 @@ export const OutlineSmall: Story = {
 		size: "small",
 		variant: "outline",
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const GhostLargeDisabled: Story = {
@@ -159,7 +159,7 @@ export const GhostLargeDisabled: Story = {
 		variant: "ghost",
 		isDisabled: true,
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const GhostLarge: Story = {
@@ -168,7 +168,7 @@ export const GhostLarge: Story = {
 		size: "large",
 		variant: "ghost",
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const GhostMedium: Story = {
@@ -177,7 +177,7 @@ export const GhostMedium: Story = {
 		size: "medium",
 		variant: "ghost",
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const GhostMediumPending: Story = {
@@ -187,7 +187,7 @@ export const GhostMediumPending: Story = {
 		variant: "ghost",
 		isPending: true,
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const GhostSmall: Story = {
@@ -196,7 +196,7 @@ export const GhostSmall: Story = {
 		size: "small",
 		variant: "ghost",
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const GrayedOutLargeDisabled: Story = {
@@ -206,7 +206,7 @@ export const GrayedOutLargeDisabled: Story = {
 		variant: "grayed-out",
 		isDisabled: true,
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const GrayedOutLarge: Story = {
@@ -216,10 +216,10 @@ export const GrayedOutLarge: Story = {
 		variant: "grayed-out",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			Button
 			<ArrowRightIcon size={18} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -229,7 +229,7 @@ export const GrayedOutMedium: Story = {
 		size: "medium",
 		variant: "grayed-out",
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const GrayedOutMediumPending: Story = {
@@ -239,7 +239,7 @@ export const GrayedOutMediumPending: Story = {
 		variant: "grayed-out",
 		isPending: true,
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };
 
 export const GrayedOutSmall: Story = {
@@ -248,5 +248,5 @@ export const GrayedOutSmall: Story = {
 		size: "small",
 		variant: "grayed-out",
 	},
-	render: (args) => <NewButton {...args}>Button</NewButton>,
+	render: (args) => <Button {...args}>Button</Button>,
 };

--- a/stories/shared/Drawer.stories.tsx
+++ b/stories/shared/Drawer.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { Drawer } from "@/_src/shared/ui/components/drawer";
 import type { Meta } from "@storybook/nextjs";
 import { useState } from "react";
@@ -18,7 +18,7 @@ export const DrawerOverlay = () => {
 	return (
 		<div className="min-w-[500px] min-h-[300px]">
 			<Drawer.Trigger>
-				<Button title="Trigger" />
+				<NewButton>Trigger</NewButton>
 				<Drawer.Modal position="end">
 					<Drawer.Heading>Drawer Heading</Drawer.Heading>
 				</Drawer.Modal>
@@ -36,10 +36,11 @@ export const DrawerInlineWithPortal = () => {
 		<div className="flex flex-row w-full min-w-[500px] min-h-[300px] bg-neutral-100">
 			<div className="w-full">
 				<p>Some content</p>
-				<Button
-					title="Trigger"
+				<NewButton
 					onPress={() => setOpen((prev) => !prev)}
-				/>
+				>
+					Trigger
+				</NewButton>
 				<p>Some content</p>
 			</div>
 			<Drawer.Modal position="end" portal="in-same-place" isOpen={isOpen}>
@@ -56,10 +57,11 @@ export const DrawerInlineResizible = () => {
 		<div className="flex flex-row w-full min-w-[500px] h-[300px] bg-neutral-100">
 			<div className="w-full">
 				<p>Some content</p>
-				<Button
-					title="Trigger"
+				<NewButton
 					onPress={() => setOpen((prev) => !prev)}
-				/>
+				>
+					Trigger
+				</NewButton>
 				<p>Some content</p>
 			</div>
 			<Drawer.ModalWithSeparator

--- a/stories/shared/Drawer.stories.tsx
+++ b/stories/shared/Drawer.stories.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { Drawer } from "@/_src/shared/ui/components/drawer";
 import type { Meta } from "@storybook/nextjs";
 import { useState } from "react";
@@ -18,7 +18,7 @@ export const DrawerOverlay = () => {
 	return (
 		<div className="min-w-[500px] min-h-[300px]">
 			<Drawer.Trigger>
-				<NewButton>Trigger</NewButton>
+				<Button>Trigger</Button>
 				<Drawer.Modal position="end">
 					<Drawer.Heading>Drawer Heading</Drawer.Heading>
 				</Drawer.Modal>
@@ -36,11 +36,11 @@ export const DrawerInlineWithPortal = () => {
 		<div className="flex flex-row w-full min-w-[500px] min-h-[300px] bg-neutral-100">
 			<div className="w-full">
 				<p>Some content</p>
-				<NewButton
+				<Button
 					onPress={() => setOpen((prev) => !prev)}
 				>
 					Trigger
-				</NewButton>
+				</Button>
 				<p>Some content</p>
 			</div>
 			<Drawer.Modal position="end" portal="in-same-place" isOpen={isOpen}>
@@ -57,11 +57,11 @@ export const DrawerInlineResizible = () => {
 		<div className="flex flex-row w-full min-w-[500px] h-[300px] bg-neutral-100">
 			<div className="w-full">
 				<p>Some content</p>
-				<NewButton
+				<Button
 					onPress={() => setOpen((prev) => !prev)}
 				>
 					Trigger
-				</NewButton>
+				</Button>
 				<p>Some content</p>
 			</div>
 			<Drawer.ModalWithSeparator

--- a/stories/shared/Highlighter.stories.tsx
+++ b/stories/shared/Highlighter.stories.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { Highlighter } from "@/_src/shared/ui/components/highlighter";
 import { PeopleIcon } from "@/_src/shared/ui/components/icon";
 import type { Meta } from "@storybook/nextjs";
@@ -19,22 +19,22 @@ export const HighlighterWithButton = () => {
 	return (
 		<div className="flex flex-row gap-8">
 			<Highlighter id="unique-button-1">
-				<NewButton>Click Me!</NewButton>
+				<Button>Click Me!</Button>
 			</Highlighter>
 			<Highlighter id="unique-button-2">
-				<NewButton variant="ghost" shape="square">
+				<Button variant="ghost" shape="square">
 					<PeopleIcon />
-				</NewButton>
+				</Button>
 			</Highlighter>
 			<Highlighter id="unique-button-3">
-				<NewButton variant="grayed-out" shape="square">
+				<Button variant="grayed-out" shape="square">
 					<PeopleIcon />
-				</NewButton>
+				</Button>
 			</Highlighter>
 			<Highlighter id="unique-button-4">
-				<NewButton variant="outline">
+				<Button variant="outline">
 					<PeopleIcon /> Click me!
-				</NewButton>
+				</Button>
 			</Highlighter>
 		</div>
 	);

--- a/stories/shared/Input.stories.tsx
+++ b/stories/shared/Input.stories.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { ArrowDownIcon, PeopleIcon } from "@/_src/shared/ui/components/icon";
 import { Input } from "@/_src/shared/ui/components/input";
 import type { Meta, StoryObj } from "@storybook/nextjs";
@@ -43,7 +43,7 @@ export const InputWithEndContent: Story = {
 		label: "Label",
 		placeholder: "Placeholder",
 		endContent: (
-			<NewButton
+			<Button
 				shape="square"
 				size="small"
 				variant="ghost"
@@ -51,7 +51,7 @@ export const InputWithEndContent: Story = {
 				excludeFromTabOrder={true}
 			>
 				<ArrowDownIcon size={16} />
-			</NewButton>
+			</Button>
 		),
 	},
 };

--- a/stories/shared/Input.stories.tsx
+++ b/stories/shared/Input.stories.tsx
@@ -1,4 +1,4 @@
-import { ButtonSquare } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { ArrowDownIcon, PeopleIcon } from "@/_src/shared/ui/components/icon";
 import { Input } from "@/_src/shared/ui/components/input";
 import type { Meta, StoryObj } from "@storybook/nextjs";
@@ -43,13 +43,15 @@ export const InputWithEndContent: Story = {
 		label: "Label",
 		placeholder: "Placeholder",
 		endContent: (
-			<ButtonSquare
-				icon={ArrowDownIcon}
+			<NewButton
+				shape="square"
 				size="small"
 				variant="ghost"
 				aria-label="autocomplete-toggle-button"
 				excludeFromTabOrder={true}
-			/>
+			>
+				<ArrowDownIcon size={16} />
+			</NewButton>
 		),
 	},
 };

--- a/stories/shared/Menu.stories.tsx
+++ b/stories/shared/Menu.stories.tsx
@@ -1,4 +1,4 @@
-import { ButtonSquare } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import {
 	CardsIcon,
 	PeopleIcon,
@@ -20,7 +20,9 @@ export default meta;
 
 export const MenuDefault = () => (
 	<Menu>
-		<ButtonSquare icon={SettingsIcon} />
+		<NewButton shape="square">
+			<SettingsIcon size={18} />
+		</NewButton>
 		<Menu.Content>
 			<Menu.Section title="Dropdown Title">
 				<Menu.Item id={1}>

--- a/stories/shared/Menu.stories.tsx
+++ b/stories/shared/Menu.stories.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import {
 	CardsIcon,
 	PeopleIcon,
@@ -20,9 +20,9 @@ export default meta;
 
 export const MenuDefault = () => (
 	<Menu>
-		<NewButton shape="square">
+		<Button shape="square">
 			<SettingsIcon size={18} />
-		</NewButton>
+		</Button>
 		<Menu.Content>
 			<Menu.Section title="Dropdown Title">
 				<Menu.Item id={1}>

--- a/stories/shared/Modal.stories.tsx
+++ b/stories/shared/Modal.stories.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { CloseIcon } from "@/_src/shared/ui/components/icon";
 import { Modal } from "@/_src/shared/ui/components/modal";
 import type { Meta } from "@storybook/nextjs";
@@ -17,19 +17,19 @@ export default meta;
 export const DialogDefault = () => {
 	return (
 		<Modal>
-			<NewButton>Trigger</NewButton>
+			<Button>Trigger</Button>
 			<Modal.Dialog isDismissable>
 				<Modal.Header>
 					{({ close }) => (
 						<>
 							<Modal.Title>Modal Header</Modal.Title>
-							<NewButton
+							<Button
 								shape="square"
 								variant="ghost"
 								onPress={close}
 							>
 								<CloseIcon size={18} />
-							</NewButton>
+							</Button>
 						</>
 					)}
 				</Modal.Header>
@@ -37,18 +37,18 @@ export const DialogDefault = () => {
 				<Modal.Footer>
 					{({ close }) => (
 						<>
-							<NewButton
+							<Button
 								onPress={close}
 								variant="ghost"
 							>
 								Cancel
-							</NewButton>
-							<NewButton
+							</Button>
+							<Button
 								onPress={close}
 								appearance="danger"
 							>
 								Delete
-							</NewButton>
+							</Button>
 						</>
 					)}
 				</Modal.Footer>

--- a/stories/shared/Modal.stories.tsx
+++ b/stories/shared/Modal.stories.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonSquare } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { CloseIcon } from "@/_src/shared/ui/components/icon";
 import { Modal } from "@/_src/shared/ui/components/modal";
 import type { Meta } from "@storybook/nextjs";
@@ -17,17 +17,19 @@ export default meta;
 export const DialogDefault = () => {
 	return (
 		<Modal>
-			<Button title="Trigger" />
+			<NewButton>Trigger</NewButton>
 			<Modal.Dialog isDismissable>
 				<Modal.Header>
 					{({ close }) => (
 						<>
 							<Modal.Title>Modal Header</Modal.Title>
-							<ButtonSquare
-								icon={CloseIcon}
+							<NewButton
+								shape="square"
 								variant="ghost"
 								onPress={close}
-							/>
+							>
+								<CloseIcon size={18} />
+							</NewButton>
 						</>
 					)}
 				</Modal.Header>
@@ -35,16 +37,18 @@ export const DialogDefault = () => {
 				<Modal.Footer>
 					{({ close }) => (
 						<>
-							<Button
-								title="Cancel"
+							<NewButton
 								onPress={close}
 								variant="ghost"
-							/>
-							<Button
-								title="Delete"
+							>
+								Cancel
+							</NewButton>
+							<NewButton
 								onPress={close}
 								appearance="danger"
-							/>
+							>
+								Delete
+							</NewButton>
 						</>
 					)}
 				</Modal.Footer>

--- a/stories/shared/Onboarding.stories.tsx
+++ b/stories/shared/Onboarding.stories.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import {
 	OnboardingProvider,
 	OnboardingStep,
@@ -35,7 +35,7 @@ function Screen() {
 	const { startOnboarding } = useOnboardingActions();
 	return (
 		<div className="relative w-full h-full min-h-[400px] p-4">
-			<NewButton
+			<Button
 				onPress={() =>
 					startOnboarding({
 						id: MODEL_ID,
@@ -44,7 +44,7 @@ function Screen() {
 				}
 			>
 				Start Onboarding
-			</NewButton>
+			</Button>
 			<OnboardingStep
 				modelId={MODEL_ID}
 				stepId={FIRST_STEP_ID}

--- a/stories/shared/Popover.stories.tsx
+++ b/stories/shared/Popover.stories.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { CloseIcon } from "@/_src/shared/ui/components/icon";
 import { Popover } from "@/_src/shared/ui/components/popover";
 import type { Meta } from "@storybook/nextjs";
@@ -17,13 +17,13 @@ export default meta;
 
 export const PopoverDefault = () => (
 	<Popover>
-		<NewButton>Click!</NewButton>
+		<Button>Click!</Button>
 		<Popover.Content placement={"bottom left"}>
 			<div className="flex flex-row gap-2 items-center p-2 ">
 				Content!
-				<NewButton shape="square" size="small" slot="close">
+				<Button shape="square" size="small" slot="close">
 					<CloseIcon size={16} />
-				</NewButton>
+				</Button>
 			</div>
 		</Popover.Content>
 	</Popover>
@@ -34,17 +34,17 @@ export const PopoverList = () => (
 		{PopoverVariants.map((variant, ind) => (
 			<div key={ind}>
 				<Popover>
-					<NewButton>{variant.title}</NewButton>
+					<Button>{variant.title}</Button>
 					<Popover.Content placement={variant.placement}>
 						<div className="flex flex-row gap-2 items-center p-2 bg-white border border-neutral-100 rounded-lg drop-shadow-lg">
 							{variant.title} content!
-							<NewButton
+							<Button
 								shape="square"
 								size="small"
 								slot="close"
 							>
 								<CloseIcon size={16} />
-							</NewButton>
+							</Button>
 						</div>
 					</Popover.Content>
 				</Popover>

--- a/stories/shared/Popover.stories.tsx
+++ b/stories/shared/Popover.stories.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonSquare } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { CloseIcon } from "@/_src/shared/ui/components/icon";
 import { Popover } from "@/_src/shared/ui/components/popover";
 import type { Meta } from "@storybook/nextjs";
@@ -17,11 +17,13 @@ export default meta;
 
 export const PopoverDefault = () => (
 	<Popover>
-		<Button title="Click!" />
+		<NewButton>Click!</NewButton>
 		<Popover.Content placement={"bottom left"}>
 			<div className="flex flex-row gap-2 items-center p-2 ">
 				Content!
-				<ButtonSquare size="small" icon={CloseIcon} slot="close" />
+				<NewButton shape="square" size="small" slot="close">
+					<CloseIcon size={16} />
+				</NewButton>
 			</div>
 		</Popover.Content>
 	</Popover>
@@ -32,15 +34,17 @@ export const PopoverList = () => (
 		{PopoverVariants.map((variant, ind) => (
 			<div key={ind}>
 				<Popover>
-					<Button title={variant.title} />
+					<NewButton>{variant.title}</NewButton>
 					<Popover.Content placement={variant.placement}>
 						<div className="flex flex-row gap-2 items-center p-2 bg-white border border-neutral-100 rounded-lg drop-shadow-lg">
 							{variant.title} content!
-							<ButtonSquare
+							<NewButton
+								shape="square"
 								size="small"
-								icon={CloseIcon}
 								slot="close"
-							/>
+							>
+								<CloseIcon size={16} />
+							</NewButton>
 						</div>
 					</Popover.Content>
 				</Popover>

--- a/stories/shared/SlidingSelector.stories.tsx
+++ b/stories/shared/SlidingSelector.stories.tsx
@@ -3,7 +3,7 @@ import {
 	PeopleIcon,
 	SettingsIcon,
 } from "@/_src/shared/ui/components/icon";
-import { ButtonSquare } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { SlidingSelector } from "@/_src/shared/ui/components/sliding-selector";
 import type { Meta } from "@storybook/nextjs";
 import { useState } from "react";
@@ -26,21 +26,27 @@ export const SlidingSelectorRow = () => {
 			containerClassName="flex flex-row gap-2"
 			selectorClassName="bg-primary-100 rounded-lg mix-blend-multiply"
 		>
-			<ButtonSquare
-				icon={ListIcon}
+			<NewButton
+				shape="square"
 				variant="ghost"
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
-			/>
-			<ButtonSquare
-				icon={SettingsIcon}
+			>
+				<ListIcon size={18} />
+			</NewButton>
+			<NewButton
+				shape="square"
 				variant="ghost"
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
-			/>
-			<ButtonSquare
-				icon={PeopleIcon}
+			>
+				<SettingsIcon size={18} />
+			</NewButton>
+			<NewButton
+				shape="square"
 				variant="ghost"
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
-			/>
+			>
+				<PeopleIcon size={18} />
+			</NewButton>
 		</SlidingSelector>
 	);
 };
@@ -51,9 +57,15 @@ export const SlidingSelectorCol = () => {
 			containerClassName="flex flex-col gap-2"
 			selectorClassName="bg-primary-200/50 rounded-lg"
 		>
-			<ButtonSquare icon={ListIcon} variant="ghost" />
-			<ButtonSquare icon={SettingsIcon} variant="ghost" />
-			<ButtonSquare icon={PeopleIcon} variant="ghost" />
+			<NewButton shape="square" variant="ghost">
+				<ListIcon size={18} />
+			</NewButton>
+			<NewButton shape="square" variant="ghost">
+				<SettingsIcon size={18} />
+			</NewButton>
+			<NewButton shape="square" variant="ghost">
+				<PeopleIcon size={18} />
+			</NewButton>
 		</SlidingSelector>
 	);
 };
@@ -64,9 +76,15 @@ export const SlidingSelectorWithDifferentSizes = () => {
 			containerClassName="flex flex-row gap-2"
 			selectorClassName="bg-primary-200 rounded-lg"
 		>
-			<ButtonSquare icon={ListIcon} variant="ghost" size="small" />
-			<ButtonSquare icon={SettingsIcon} variant="ghost" size="medium" />
-			<ButtonSquare icon={PeopleIcon} variant="ghost" size="large" />
+			<NewButton shape="square" variant="ghost" size="small">
+				<ListIcon size={16} />
+			</NewButton>
+			<NewButton shape="square" variant="ghost" size="medium">
+				<SettingsIcon size={18} />
+			</NewButton>
+			<NewButton shape="square" variant="ghost" size="large">
+				<PeopleIcon size={24} />
+			</NewButton>
 		</SlidingSelector>
 	);
 };
@@ -80,30 +98,36 @@ export const SlidingSelectorControllable = () => {
 			onSelectionReset={() => setActiveElement(null)}
 			selectorClassName="bg-primary-100 rounded-lg mix-blend-multiply"
 		>
-			<ButtonSquare
-				icon={ListIcon}
+			<NewButton
+				shape="square"
 				variant="ghost"
 				onPress={() =>
 					setActiveElement((prev) => (prev === 0 ? null : 0))
 				}
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
-			/>
-			<ButtonSquare
-				icon={SettingsIcon}
+			>
+				<ListIcon size={18} />
+			</NewButton>
+			<NewButton
+				shape="square"
 				variant="ghost"
 				onPress={() =>
 					setActiveElement((prev) => (prev === 1 ? null : 1))
 				}
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
-			/>
-			<ButtonSquare
-				icon={PeopleIcon}
+			>
+				<SettingsIcon size={18} />
+			</NewButton>
+			<NewButton
+				shape="square"
 				variant="ghost"
 				onPress={() =>
 					setActiveElement((prev) => (prev === 2 ? null : 2))
 				}
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
-			/>
+			>
+				<PeopleIcon size={18} />
+			</NewButton>
 		</SlidingSelector>
 	);
 };

--- a/stories/shared/SlidingSelector.stories.tsx
+++ b/stories/shared/SlidingSelector.stories.tsx
@@ -3,7 +3,7 @@ import {
 	PeopleIcon,
 	SettingsIcon,
 } from "@/_src/shared/ui/components/icon";
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { SlidingSelector } from "@/_src/shared/ui/components/sliding-selector";
 import type { Meta } from "@storybook/nextjs";
 import { useState } from "react";
@@ -26,27 +26,27 @@ export const SlidingSelectorRow = () => {
 			containerClassName="flex flex-row gap-2"
 			selectorClassName="bg-primary-100 rounded-lg mix-blend-multiply"
 		>
-			<NewButton
+			<Button
 				shape="square"
 				variant="ghost"
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
 			>
 				<ListIcon size={18} />
-			</NewButton>
-			<NewButton
+			</Button>
+			<Button
 				shape="square"
 				variant="ghost"
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
 			>
 				<SettingsIcon size={18} />
-			</NewButton>
-			<NewButton
+			</Button>
+			<Button
 				shape="square"
 				variant="ghost"
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
 			>
 				<PeopleIcon size={18} />
-			</NewButton>
+			</Button>
 		</SlidingSelector>
 	);
 };
@@ -57,15 +57,15 @@ export const SlidingSelectorCol = () => {
 			containerClassName="flex flex-col gap-2"
 			selectorClassName="bg-primary-200/50 rounded-lg"
 		>
-			<NewButton shape="square" variant="ghost">
+			<Button shape="square" variant="ghost">
 				<ListIcon size={18} />
-			</NewButton>
-			<NewButton shape="square" variant="ghost">
+			</Button>
+			<Button shape="square" variant="ghost">
 				<SettingsIcon size={18} />
-			</NewButton>
-			<NewButton shape="square" variant="ghost">
+			</Button>
+			<Button shape="square" variant="ghost">
 				<PeopleIcon size={18} />
-			</NewButton>
+			</Button>
 		</SlidingSelector>
 	);
 };
@@ -76,15 +76,15 @@ export const SlidingSelectorWithDifferentSizes = () => {
 			containerClassName="flex flex-row gap-2"
 			selectorClassName="bg-primary-200 rounded-lg"
 		>
-			<NewButton shape="square" variant="ghost" size="small">
+			<Button shape="square" variant="ghost" size="small">
 				<ListIcon size={16} />
-			</NewButton>
-			<NewButton shape="square" variant="ghost" size="medium">
+			</Button>
+			<Button shape="square" variant="ghost" size="medium">
 				<SettingsIcon size={18} />
-			</NewButton>
-			<NewButton shape="square" variant="ghost" size="large">
+			</Button>
+			<Button shape="square" variant="ghost" size="large">
 				<PeopleIcon size={24} />
-			</NewButton>
+			</Button>
 		</SlidingSelector>
 	);
 };
@@ -98,7 +98,7 @@ export const SlidingSelectorControllable = () => {
 			onSelectionReset={() => setActiveElement(null)}
 			selectorClassName="bg-primary-100 rounded-lg mix-blend-multiply"
 		>
-			<NewButton
+			<Button
 				shape="square"
 				variant="ghost"
 				onPress={() =>
@@ -107,8 +107,8 @@ export const SlidingSelectorControllable = () => {
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
 			>
 				<ListIcon size={18} />
-			</NewButton>
-			<NewButton
+			</Button>
+			<Button
 				shape="square"
 				variant="ghost"
 				onPress={() =>
@@ -117,8 +117,8 @@ export const SlidingSelectorControllable = () => {
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
 			>
 				<SettingsIcon size={18} />
-			</NewButton>
-			<NewButton
+			</Button>
+			<Button
 				shape="square"
 				variant="ghost"
 				onPress={() =>
@@ -127,7 +127,7 @@ export const SlidingSelectorControllable = () => {
 				className="bg-opacity-0 data-[sliding-selector-element-active=true]:text-primary-500"
 			>
 				<PeopleIcon size={18} />
-			</NewButton>
+			</Button>
 		</SlidingSelector>
 	);
 };

--- a/stories/shared/SquareButton.stories.tsx
+++ b/stories/shared/SquareButton.stories.tsx
@@ -1,4 +1,4 @@
-import { ButtonSquare } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { SettingsIcon } from "@/_src/shared/ui/components/icon";
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { fn } from "storybook/test";
@@ -6,7 +6,7 @@ import { fn } from "storybook/test";
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
 	title: "Shared/ButtonSquare",
-	component: ButtonSquare,
+	component: NewButton,
 	parameters: {
 		// Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
 		layout: "centered",
@@ -16,16 +16,21 @@ const meta = {
 	// More on argTypes: https://storybook.js.org/docs/api/argtypes
 	argTypes: {},
 	// Use `fn` to spy on the onPress arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
-	args: { onPress: fn() },
-} satisfies Meta<typeof ButtonSquare>;
+	args: { onPress: fn(), shape: "square" },
+} satisfies Meta<typeof NewButton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 const Default: Story = {
 	args: {
-		icon: SettingsIcon,
+		shape: "square",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={18} />
+		</NewButton>
+	),
 };
 
 export const DefaultLargeDisabled: Story = {
@@ -34,6 +39,11 @@ export const DefaultLargeDisabled: Story = {
 		size: "large",
 		isDisabled: true,
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={24} />
+		</NewButton>
+	),
 };
 
 export const DefaultLargePending: Story = {
@@ -42,6 +52,11 @@ export const DefaultLargePending: Story = {
 		size: "large",
 		isPending: true,
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={24} />
+		</NewButton>
+	),
 };
 
 export const DefaultLarge: Story = {
@@ -49,10 +64,19 @@ export const DefaultLarge: Story = {
 		...Default.args,
 		size: "large",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={24} />
+		</NewButton>
+	),
 };
 
 export const DefaultMedium = () => {
-	return <ButtonSquare icon={SettingsIcon} />;
+	return (
+		<NewButton shape="square">
+			<SettingsIcon size={18} />
+		</NewButton>
+	);
 };
 
 export const DefaultSmall: Story = {
@@ -60,6 +84,11 @@ export const DefaultSmall: Story = {
 		...Default.args,
 		size: "small",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={16} />
+		</NewButton>
+	),
 };
 
 export const OutlineLargeDisabled: Story = {
@@ -69,6 +98,11 @@ export const OutlineLargeDisabled: Story = {
 		variant: "outline",
 		isDisabled: true,
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={24} />
+		</NewButton>
+	),
 };
 
 export const OutlineLarge: Story = {
@@ -77,6 +111,11 @@ export const OutlineLarge: Story = {
 		size: "large",
 		variant: "outline",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={24} />
+		</NewButton>
+	),
 };
 
 export const OutlineMedium: Story = {
@@ -85,6 +124,11 @@ export const OutlineMedium: Story = {
 		size: "medium",
 		variant: "outline",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={18} />
+		</NewButton>
+	),
 };
 
 export const OutlineSmall: Story = {
@@ -93,6 +137,11 @@ export const OutlineSmall: Story = {
 		size: "small",
 		variant: "outline",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={16} />
+		</NewButton>
+	),
 };
 
 export const GhostLargeDisabled: Story = {
@@ -102,6 +151,11 @@ export const GhostLargeDisabled: Story = {
 		variant: "ghost",
 		isDisabled: true,
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={24} />
+		</NewButton>
+	),
 };
 
 export const GhostLarge: Story = {
@@ -110,6 +164,11 @@ export const GhostLarge: Story = {
 		size: "large",
 		variant: "ghost",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={24} />
+		</NewButton>
+	),
 };
 
 export const GhostMedium: Story = {
@@ -118,6 +177,11 @@ export const GhostMedium: Story = {
 		size: "medium",
 		variant: "ghost",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={18} />
+		</NewButton>
+	),
 };
 
 export const GhostSmall: Story = {
@@ -126,6 +190,11 @@ export const GhostSmall: Story = {
 		size: "small",
 		variant: "ghost",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={16} />
+		</NewButton>
+	),
 };
 
 export const GrayedOutLargeDisabled: Story = {
@@ -135,6 +204,11 @@ export const GrayedOutLargeDisabled: Story = {
 		variant: "grayed-out",
 		isDisabled: true,
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={24} />
+		</NewButton>
+	),
 };
 
 export const GrayedOutLarge: Story = {
@@ -143,6 +217,11 @@ export const GrayedOutLarge: Story = {
 		size: "large",
 		variant: "grayed-out",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={24} />
+		</NewButton>
+	),
 };
 
 export const GrayedOutMedium: Story = {
@@ -151,6 +230,11 @@ export const GrayedOutMedium: Story = {
 		size: "medium",
 		variant: "grayed-out",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={18} />
+		</NewButton>
+	),
 };
 
 export const GrayedOutSmall: Story = {
@@ -159,4 +243,9 @@ export const GrayedOutSmall: Story = {
 		size: "small",
 		variant: "grayed-out",
 	},
+	render: (args) => (
+		<NewButton {...args}>
+			<SettingsIcon size={16} />
+		</NewButton>
+	),
 };

--- a/stories/shared/SquareButton.stories.tsx
+++ b/stories/shared/SquareButton.stories.tsx
@@ -25,12 +25,9 @@ type Story = StoryObj<typeof meta>;
 const Default: Story = {
 	args: {
 		shape: "square",
+		children: <SettingsIcon size={18} />,
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={18} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const DefaultLargeDisabled: Story = {
@@ -39,11 +36,7 @@ export const DefaultLargeDisabled: Story = {
 		size: "large",
 		isDisabled: true,
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={24} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const DefaultLargePending: Story = {
@@ -52,11 +45,7 @@ export const DefaultLargePending: Story = {
 		size: "large",
 		isPending: true,
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={24} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const DefaultLarge: Story = {
@@ -64,11 +53,7 @@ export const DefaultLarge: Story = {
 		...Default.args,
 		size: "large",
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={24} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const DefaultMedium = () => {
@@ -84,11 +69,7 @@ export const DefaultSmall: Story = {
 		...Default.args,
 		size: "small",
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={16} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const OutlineLargeDisabled: Story = {
@@ -98,11 +79,7 @@ export const OutlineLargeDisabled: Story = {
 		variant: "outline",
 		isDisabled: true,
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={24} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const OutlineLarge: Story = {
@@ -111,11 +88,7 @@ export const OutlineLarge: Story = {
 		size: "large",
 		variant: "outline",
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={24} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const OutlineMedium: Story = {
@@ -124,11 +97,7 @@ export const OutlineMedium: Story = {
 		size: "medium",
 		variant: "outline",
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={18} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const OutlineSmall: Story = {
@@ -137,11 +106,7 @@ export const OutlineSmall: Story = {
 		size: "small",
 		variant: "outline",
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={16} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const GhostLargeDisabled: Story = {
@@ -151,11 +116,7 @@ export const GhostLargeDisabled: Story = {
 		variant: "ghost",
 		isDisabled: true,
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={24} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const GhostLarge: Story = {
@@ -164,11 +125,7 @@ export const GhostLarge: Story = {
 		size: "large",
 		variant: "ghost",
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={24} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const GhostMedium: Story = {
@@ -177,11 +134,7 @@ export const GhostMedium: Story = {
 		size: "medium",
 		variant: "ghost",
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={18} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const GhostSmall: Story = {
@@ -190,11 +143,7 @@ export const GhostSmall: Story = {
 		size: "small",
 		variant: "ghost",
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={16} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const GrayedOutLargeDisabled: Story = {
@@ -204,11 +153,7 @@ export const GrayedOutLargeDisabled: Story = {
 		variant: "grayed-out",
 		isDisabled: true,
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={24} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const GrayedOutLarge: Story = {
@@ -217,11 +162,7 @@ export const GrayedOutLarge: Story = {
 		size: "large",
 		variant: "grayed-out",
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={24} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const GrayedOutMedium: Story = {
@@ -230,11 +171,7 @@ export const GrayedOutMedium: Story = {
 		size: "medium",
 		variant: "grayed-out",
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={18} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };
 
 export const GrayedOutSmall: Story = {
@@ -243,9 +180,5 @@ export const GrayedOutSmall: Story = {
 		size: "small",
 		variant: "grayed-out",
 	},
-	render: (args) => (
-		<Button {...args}>
-			<SettingsIcon size={16} />
-		</Button>
-	),
+	render: (args) => <Button {...args} />,
 };

--- a/stories/shared/SquareButton.stories.tsx
+++ b/stories/shared/SquareButton.stories.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { SettingsIcon } from "@/_src/shared/ui/components/icon";
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { fn } from "storybook/test";
@@ -6,7 +6,7 @@ import { fn } from "storybook/test";
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
 	title: "Shared/ButtonSquare",
-	component: NewButton,
+	component: Button,
 	parameters: {
 		// Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
 		layout: "centered",
@@ -17,7 +17,7 @@ const meta = {
 	argTypes: {},
 	// Use `fn` to spy on the onPress arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
 	args: { onPress: fn(), shape: "square" },
-} satisfies Meta<typeof NewButton>;
+} satisfies Meta<typeof Button>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -27,9 +27,9 @@ const Default: Story = {
 		shape: "square",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={18} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -40,9 +40,9 @@ export const DefaultLargeDisabled: Story = {
 		isDisabled: true,
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={24} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -53,9 +53,9 @@ export const DefaultLargePending: Story = {
 		isPending: true,
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={24} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -65,17 +65,17 @@ export const DefaultLarge: Story = {
 		size: "large",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={24} />
-		</NewButton>
+		</Button>
 	),
 };
 
 export const DefaultMedium = () => {
 	return (
-		<NewButton shape="square">
+		<Button shape="square">
 			<SettingsIcon size={18} />
-		</NewButton>
+		</Button>
 	);
 };
 
@@ -85,9 +85,9 @@ export const DefaultSmall: Story = {
 		size: "small",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={16} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -99,9 +99,9 @@ export const OutlineLargeDisabled: Story = {
 		isDisabled: true,
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={24} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -112,9 +112,9 @@ export const OutlineLarge: Story = {
 		variant: "outline",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={24} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -125,9 +125,9 @@ export const OutlineMedium: Story = {
 		variant: "outline",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={18} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -138,9 +138,9 @@ export const OutlineSmall: Story = {
 		variant: "outline",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={16} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -152,9 +152,9 @@ export const GhostLargeDisabled: Story = {
 		isDisabled: true,
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={24} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -165,9 +165,9 @@ export const GhostLarge: Story = {
 		variant: "ghost",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={24} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -178,9 +178,9 @@ export const GhostMedium: Story = {
 		variant: "ghost",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={18} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -191,9 +191,9 @@ export const GhostSmall: Story = {
 		variant: "ghost",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={16} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -205,9 +205,9 @@ export const GrayedOutLargeDisabled: Story = {
 		isDisabled: true,
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={24} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -218,9 +218,9 @@ export const GrayedOutLarge: Story = {
 		variant: "grayed-out",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={24} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -231,9 +231,9 @@ export const GrayedOutMedium: Story = {
 		variant: "grayed-out",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={18} />
-		</NewButton>
+		</Button>
 	),
 };
 
@@ -244,8 +244,8 @@ export const GrayedOutSmall: Story = {
 		variant: "grayed-out",
 	},
 	render: (args) => (
-		<NewButton {...args}>
+		<Button {...args}>
 			<SettingsIcon size={16} />
-		</NewButton>
+		</Button>
 	),
 };

--- a/stories/shared/Toast.stories.tsx
+++ b/stories/shared/Toast.stories.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import {
 	ToastProvider,
 	useGlobalToast,
@@ -36,7 +36,7 @@ function ToastTrigger() {
 
 	return (
 		<div className="absolute top-1/2 left-1/2 grid -translate-x-1/2 -translate-y-1/2 grid-flow-row grid-cols-3 gap-2">
-			<NewButton
+			<Button
 				appearance="neutral"
 				onPress={() => {
 					toastState?.add({
@@ -49,8 +49,8 @@ function ToastTrigger() {
 				}}
 			>
 				Neutral!
-			</NewButton>
-			<NewButton
+			</Button>
+			<Button
 				appearance="info"
 				onPress={() => {
 					toastState?.add({
@@ -63,8 +63,8 @@ function ToastTrigger() {
 				}}
 			>
 				Info!
-			</NewButton>
-			<NewButton
+			</Button>
+			<Button
 				appearance="warning"
 				onPress={() => {
 					toastState?.add({
@@ -77,8 +77,8 @@ function ToastTrigger() {
 				}}
 			>
 				Warning!
-			</NewButton>
-			<NewButton
+			</Button>
+			<Button
 				appearance="danger"
 				onPress={() => {
 					toastState?.add({
@@ -91,8 +91,8 @@ function ToastTrigger() {
 				}}
 			>
 				Error!
-			</NewButton>
-			<NewButton
+			</Button>
+			<Button
 				appearance="success"
 				onPress={() => {
 					toastState?.add({
@@ -105,8 +105,8 @@ function ToastTrigger() {
 				}}
 			>
 				Success!
-			</NewButton>
-			<NewButton
+			</Button>
+			<Button
 				onPress={() => {
 					toastState?.add(
 						{
@@ -121,8 +121,8 @@ function ToastTrigger() {
 				}}
 			>
 				Dismissable!
-			</NewButton>
-			<NewButton
+			</Button>
+			<Button
 				variant="outline"
 				onPress={() => {
 					setTimeout(() => {
@@ -136,7 +136,7 @@ function ToastTrigger() {
 				}}
 			>
 				Toast with timeout
-			</NewButton>
+			</Button>
 		</div>
 	);
 }

--- a/stories/shared/Toast.stories.tsx
+++ b/stories/shared/Toast.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import {
 	ToastProvider,
 	useGlobalToast,
@@ -36,8 +36,7 @@ function ToastTrigger() {
 
 	return (
 		<div className="absolute top-1/2 left-1/2 grid -translate-x-1/2 -translate-y-1/2 grid-flow-row grid-cols-3 gap-2">
-			<Button
-				title="Neutral!"
+			<NewButton
 				appearance="neutral"
 				onPress={() => {
 					toastState?.add({
@@ -48,9 +47,10 @@ function ToastTrigger() {
 					});
 					setIncrement((prev) => prev + 1);
 				}}
-			/>
-			<Button
-				title="Info!"
+			>
+				Neutral!
+			</NewButton>
+			<NewButton
 				appearance="info"
 				onPress={() => {
 					toastState?.add({
@@ -61,9 +61,10 @@ function ToastTrigger() {
 					});
 					setIncrement((prev) => prev + 1);
 				}}
-			/>
-			<Button
-				title="Warning!"
+			>
+				Info!
+			</NewButton>
+			<NewButton
 				appearance="warning"
 				onPress={() => {
 					toastState?.add({
@@ -74,9 +75,10 @@ function ToastTrigger() {
 					});
 					setIncrement((prev) => prev + 1);
 				}}
-			/>
-			<Button
-				title="Error!"
+			>
+				Warning!
+			</NewButton>
+			<NewButton
 				appearance="danger"
 				onPress={() => {
 					toastState?.add({
@@ -87,9 +89,10 @@ function ToastTrigger() {
 					});
 					setIncrement((prev) => prev + 1);
 				}}
-			/>
-			<Button
-				title="Success!"
+			>
+				Error!
+			</NewButton>
+			<NewButton
 				appearance="success"
 				onPress={() => {
 					toastState?.add({
@@ -100,9 +103,10 @@ function ToastTrigger() {
 					});
 					setIncrement((prev) => prev + 1);
 				}}
-			/>
-			<Button
-				title="Dismissable!"
+			>
+				Success!
+			</NewButton>
+			<NewButton
 				onPress={() => {
 					toastState?.add(
 						{
@@ -115,9 +119,10 @@ function ToastTrigger() {
 					);
 					setIncrement((prev) => prev + 1);
 				}}
-			/>
-			<Button
-				title="Toast with timeout"
+			>
+				Dismissable!
+			</NewButton>
+			<NewButton
 				variant="outline"
 				onPress={() => {
 					setTimeout(() => {
@@ -129,7 +134,9 @@ function ToastTrigger() {
 						setIncrement((prev) => prev + 1);
 					}, 2000);
 				}}
-			/>
+			>
+				Toast with timeout
+			</NewButton>
 		</div>
 	);
 }

--- a/stories/shared/Tooltip.stories.tsx
+++ b/stories/shared/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import { NewButton } from "@/_src/shared/ui/components/button";
+import { Button } from "@/_src/shared/ui/components/button";
 import { Tooltip } from "@/_src/shared/ui/components/tooltip";
 import type { Meta } from "@storybook/nextjs";
 
@@ -17,7 +17,7 @@ export default meta;
 export const TooltipDefault = () => {
 	return (
 		<Tooltip defaultOpen={true}>
-			<NewButton>Trigger</NewButton>
+			<Button>Trigger</Button>
 			<Tooltip.Content>Content</Tooltip.Content>
 		</Tooltip>
 	);
@@ -26,7 +26,7 @@ export const TooltipDefault = () => {
 export const TooltipWithCustomClassName = () => {
 	return (
 		<Tooltip defaultOpen={true}>
-			<NewButton>Trigger</NewButton>
+			<Button>Trigger</Button>
 			<Tooltip.Content className="bg-info-500 text-white">
 				Content
 			</Tooltip.Content>

--- a/stories/shared/Tooltip.stories.tsx
+++ b/stories/shared/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/_src/shared/ui/components/button";
+import { NewButton } from "@/_src/shared/ui/components/button";
 import { Tooltip } from "@/_src/shared/ui/components/tooltip";
 import type { Meta } from "@storybook/nextjs";
 
@@ -17,7 +17,7 @@ export default meta;
 export const TooltipDefault = () => {
 	return (
 		<Tooltip defaultOpen={true}>
-			<Button title="Trigger" />
+			<NewButton>Trigger</NewButton>
 			<Tooltip.Content>Content</Tooltip.Content>
 		</Tooltip>
 	);
@@ -26,7 +26,7 @@ export const TooltipDefault = () => {
 export const TooltipWithCustomClassName = () => {
 	return (
 		<Tooltip defaultOpen={true}>
-			<Button title="Trigger" />
+			<NewButton>Trigger</NewButton>
 			<Tooltip.Content className="bg-info-500 text-white">
 				Content
 			</Tooltip.Content>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Consolidates button components into a single, child-based `Button` API and updates all usages across the app.
> 
> - Replaces `ButtonSquare` and `NewButton` with `Button` (adds `shape="square"`, `isPending` spinner hides children for square)
> - Deprecates `title`/`contentLeft`/`contentRight` props; buttons now rendered via children with icons/text
> - Refactors pages (game create/join, game room controls, voting, tickets, user bar, main header/sections) to the new API
> - Updates shared UI (menus, popovers, tooltips, autocomplete, inline-edit, toast, error boundary, cookie consent, confirmation modal) to use `Button`
> - Adjusts tests and Storybook stories accordingly; button index now exports only `Button`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5225a86db66e3d9f686b70e20e37650a9268a9bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->