### PR TITLE
a11y improvements

### DIFF
--- a/src/app/(game)/layout.tsx
+++ b/src/app/(game)/layout.tsx
@@ -6,8 +6,6 @@ export default function GameLayout({
 }: {
 	children: React.ReactNode;
 }) {
-	console.log("GameLayout");
-
 	return (
 		<DomainProvider>
 			<ConfirmationModalProvider>{children}</ConfirmationModalProvider>

--- a/src/shared/ui/components/autocomplete/components/autocomplete-list.tsx
+++ b/src/shared/ui/components/autocomplete/components/autocomplete-list.tsx
@@ -5,15 +5,7 @@ import {
 	StyleProps,
 	FocusStrategy,
 } from "@react-types/shared";
-import {
-	ForwardedRef,
-	forwardRef,
-	HTMLAttributes,
-	RefObject,
-	ReactNode,
-	useMemo,
-	useRef,
-} from "react";
+import { HTMLAttributes, RefObject, ReactNode, useMemo, useRef } from "react";
 import { AriaListBoxOptions, useListBox } from "react-aria";
 import { AutocompleteListContext } from "../contexts/autocomplete-list-context";
 import { AutocompleteListOption } from "./autocomplete-list-option";
@@ -34,75 +26,72 @@ export type AutocompleteListProps<TItemData extends object> = {
 	onLoadMore?: () => void;
 	renderEmptyState?: () => ReactNode;
 	onScroll?: () => void;
+	ref?: RefObject<HTMLDivElement | null>;
 } & AriaListBoxOptions<TItemData> &
 	DOMProps &
 	AriaLabelingProps &
 	StyleProps;
 
-export const AutocompleteList = forwardRef(
-	(
-		props: AutocompleteListProps<object>,
-		ref: ForwardedRef<HTMLDivElement>,
-	) => {
-		const {
-			state,
-			renderEmptyState,
-			shouldFocusOnHover = false,
-			shouldUseVirtualFocus = false,
-		} = props;
+export function AutocompleteList(props: AutocompleteListProps<object>) {
+	const {
+		state,
+		renderEmptyState,
+		shouldFocusOnHover = false,
+		shouldUseVirtualFocus = false,
+		ref,
+	} = props;
 
-		const listRef: RefObject<HTMLDivElement | null> = useRef(null);
-		const { listBoxProps } = useListBox(
-			{ ...props, shouldUseVirtualFocus: false },
-			state,
-			listRef,
-		);
+	const listRef: RefObject<HTMLDivElement | null> = useRef(null);
+	const { listBoxProps } = useListBox(
+		{ ...props, shouldUseVirtualFocus: false },
+		state,
+		listRef,
+	);
 
-		const renderedItems = useMemo(
-			() => [...state.collection],
-			[state.collection],
-		);
+	const renderedItems = useMemo(
+		() => [...state.collection],
+		[state.collection],
+	);
 
-		return (
-			<AutocompleteListContext.Provider
-				value={{
-					state,
-					shouldFocusOnHover,
-					shouldUseVirtualFocus,
-				}}
+	return (
+		<AutocompleteListContext.Provider
+			value={{
+				state,
+				shouldFocusOnHover,
+				shouldUseVirtualFocus,
+			}}
+		>
+			<div
+				{...listBoxProps}
+				ref={setRefs(listRef, ref)}
+				className="max-h-[inherit] overflow-auto outline-hidden flex flex-col gap-2"
 			>
-				<div
-					{...listBoxProps}
-					ref={setRefs(listRef, ref)}
-					className="max-h-[inherit] overflow-auto outline-hidden flex flex-col gap-2"
-				>
-					{renderedItems.length === 0 && renderEmptyState
-						? renderEmptyState()
-						: null}
-					{renderedItems.map((item) => {
-						if (item.type === "section") {
-							return (
-								<AutocompleteListSection
-									item={item}
-									key={item.key}
-								/>
-							);
-						}
-						if (item.type === "item") {
-							return (
-								<AutocompleteListOption
-									item={item}
-									key={item.key}
-								/>
-							);
-						}
-						if (item.type === "separator") {
-							return <div key={item.key} />;
-						}
-						return null;
-					})}
-				</div>
-			</AutocompleteListContext.Provider>
-		);
-	},
-);
+				{renderedItems.length === 0 && renderEmptyState
+					? renderEmptyState()
+					: null}
+				{renderedItems.map((item) => {
+					if (item.type === "section") {
+						return (
+							<AutocompleteListSection
+								item={item}
+								key={item.key}
+							/>
+						);
+					}
+					if (item.type === "item") {
+						return (
+							<AutocompleteListOption
+								item={item}
+								key={item.key}
+							/>
+						);
+					}
+					if (item.type === "separator") {
+						return <div key={item.key} />;
+					}
+					return null;
+				})}
+			</div>
+		</AutocompleteListContext.Provider>
+	);
+}

--- a/src/shared/ui/components/autocomplete/components/autocomplete-value.tsx
+++ b/src/shared/ui/components/autocomplete/components/autocomplete-value.tsx
@@ -60,7 +60,7 @@ function AutocompleteSingleValue() {
 					shape="square"
 					size="small"
 					variant="ghost"
-					aria-label="autocomplete-toggle-button"
+					aria-label="Toggle suggestions"
 					excludeFromTabOrder={true}
 					{...toggleBtnProps}
 				>
@@ -106,7 +106,7 @@ function AutocompleteMultipleValue() {
 					size="small"
 					data-testid="trigger"
 					variant="ghost"
-					aria-label="autocomplete-toggle-button"
+					aria-label="Toggle suggestions"
 					excludeFromTabOrder={true}
 					{...toggleBtnProps}
 				>
@@ -215,7 +215,6 @@ function AutocompleteMultipleValue() {
 				className={multipleValueLabelStyles({
 					isDisabled: isDisabled,
 				})}
-				aria-label="Label"
 				htmlFor="multiple-autocomplete-input"
 			>
 				{inputProps.label}

--- a/src/shared/ui/components/button/component.tsx
+++ b/src/shared/ui/components/button/component.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { forwardRef, HTMLAttributes, ReactNode } from "react";
+import { HTMLAttributes, ReactNode, RefObject } from "react";
 import {
 	ButtonContext,
 	ButtonProps,
@@ -27,75 +27,75 @@ type ButtonComponentProps = {
 	isPending?: boolean;
 	children: ReactNode;
 	shape?: "default" | "square";
+	ref?: RefObject<HTMLButtonElement | null>;
 } & ButtonStylesProps &
 	ButtonProps &
 	HTMLAttributes<HTMLButtonElement>;
 
-export const Button = forwardRef<HTMLButtonElement, ButtonComponentProps>(
-	(props, ref) => {
-		[props, ref] = useContextProps(props, ref, ButtonContext);
-		const {
-			size = "medium",
-			variant = "default",
-			appearance = "primary",
-			isPending = false,
-			shape = "default",
-			children,
-			role,
-			className,
-		} = props;
+export function Button(props: ButtonComponentProps) {
+	let { ref, ...restProps } = props;
+	[restProps, ref] = useContextProps(restProps, ref, ButtonContext);
+	const {
+		size = "medium",
+		variant = "default",
+		appearance = "primary",
+		isPending = false,
+		shape = "default",
+		children,
+		role,
+		className,
+	} = restProps;
 
-		const { buttonProps, isPressed } = useButton(
-			{
-				...props,
-				isDisabled: props.isDisabled || isPending,
-			},
-			ref,
-		);
-		const { hoverProps, isHovered } = useHover({
-			...props,
-			isDisabled: props.isDisabled || isPending,
-		});
-		const { focusProps, isFocused, isFocusVisible } = useFocusRing(props);
+	const { buttonProps, isPressed } = useButton(
+		{
+			...restProps,
+			isDisabled: restProps.isDisabled || isPending,
+		},
+		ref,
+	);
+	const { hoverProps, isHovered } = useHover({
+		...restProps,
+		isDisabled: restProps.isDisabled || isPending,
+	});
+	const { focusProps, isFocused, isFocusVisible } = useFocusRing(restProps);
 
-		const isChildrenVisible = !(isPending && shape === "square");
+	const isChildrenVisible = !(isPending && shape === "square");
 
-		return (
-			<button
-				style={COLOR_SCHEMES[appearance] as React.CSSProperties}
-				className={twMerge(
-					buttonStyles({
-						size,
-						variant,
-						form: shape,
-						excludeFromFocus: props.excludeFromTabOrder,
-						// we need to get the ButtonContextValue from the context, but for some reason it's not exposed for public usage
-						isPressed:
-							isPressed ||
-							(
-								props as ButtonComponentProps & {
-									isPressed?: boolean;
-								}
-							).isPressed,
-						isFocused: isFocusVisible,
-						isHovered,
-						isDisabled: props.isDisabled || isPending,
-					}),
-					className,
-				)}
-				ref={ref}
-				role={role || "button"}
-				data-focused={isFocused || undefined}
-				aria-label={buttonProps["aria-label"] || "icon button"}
-				{...mergeProps(buttonProps, focusProps, hoverProps)}
-			>
-				<div className={spinnerStyles({ isActive: isPending })}>
-					<div>
-						<div className="border-r-primary-500 animate-rotation-linear aspect-square w-4 rounded-full border-2 border-y-neutral-200 border-l-neutral-200" />
-					</div>
+	return (
+		<button
+			style={COLOR_SCHEMES[appearance] as React.CSSProperties}
+			className={twMerge(
+				buttonStyles({
+					size,
+					variant,
+					form: shape,
+					excludeFromFocus: restProps.excludeFromTabOrder,
+					// we need to get the ButtonContextValue from the context, but for some reason it's not exposed for public usage
+					isPressed:
+						isPressed ||
+						(
+							restProps as ButtonComponentProps & {
+								isPressed?: boolean;
+							}
+						).isPressed,
+					isFocused: isFocusVisible,
+					isHovered,
+					isDisabled: restProps.isDisabled || isPending,
+				}),
+				className,
+			)}
+			ref={ref}
+			role={role || "button"}
+			data-focused={isFocused || undefined}
+			aria-label={buttonProps["aria-label"] || "icon button"}
+			{...mergeProps(buttonProps, focusProps, hoverProps)}
+		>
+			<div className={spinnerStyles({ isActive: isPending })}>
+				<div>
+					<div className="border-r-primary-500 animate-rotation-linear aspect-square w-4 rounded-full border-2 border-y-neutral-200 border-l-neutral-200" />
 				</div>
-				{isChildrenVisible && children}
-			</button>
-		);
-	},
-);
+			</div>
+			{isChildrenVisible && children}
+		</button>
+	);
+}

--- a/src/shared/ui/components/drawer/components/drawer-content-with-separartor.tsx
+++ b/src/shared/ui/components/drawer/components/drawer-content-with-separartor.tsx
@@ -22,6 +22,7 @@ export function DrawerModalWithSeparator(props: ModalPropsWithSeparator) {
 		stateKey,
 		minWidth,
 		maxWidth,
+		"aria-label": ariaLabel = "Drawer",
 	} = props;
 	const contentRef = useRef<HTMLDivElement | null>(null);
 	const orientation = "vertical";
@@ -119,7 +120,7 @@ export function DrawerModalWithSeparator(props: ModalPropsWithSeparator) {
 	return (
 		<div
 			className={inlineDrawerStyles({ orientation })}
-			aria-label="Drawer Dialog"
+			aria-label={ariaLabel}
 		>
 			<Separator
 				contentRef={contentRef}

--- a/src/shared/ui/components/drawer/components/drawer-content.tsx
+++ b/src/shared/ui/components/drawer/components/drawer-content.tsx
@@ -14,6 +14,7 @@ export type ModalBaseProps = {
 	isOpen?: boolean;
 	onOpenChange?: (_isOpen: boolean) => void;
 	className?: string;
+	"aria-label"?: string;
 };
 
 type ModalProps = {
@@ -27,6 +28,7 @@ export function DrawerModal(props: ModalProps) {
 		isOpen,
 		onOpenChange,
 		className,
+		"aria-label": ariaLabel = "Drawer",
 	} = props;
 	const contentRef = useRef<HTMLDivElement | null>(null);
 	const orientation = "vertical";
@@ -43,7 +45,7 @@ export function DrawerModal(props: ModalProps) {
 				<Modal className={modalStyles({ type: "overlay", position })}>
 					<Dialog
 						className={dialogStyles({ orientation })}
-						aria-label="Drawer Dialog"
+						aria-label={ariaLabel}
 					>
 						<div
 							className={twMerge(

--- a/src/shared/ui/components/drawer/components/drawer-separator.tsx
+++ b/src/shared/ui/components/drawer/components/drawer-separator.tsx
@@ -50,7 +50,7 @@ export function Separator({
 			/>
 			<Button
 				className={collapseBtnStyles({ orientation: "vertical" })}
-				aria-label="collapse-button"
+				aria-label="Collapse drawer"
 				onPress={onCollapse}
 			>
 				<ArrowRightSimpleIcon size={14} thikness="bold" />

--- a/src/shared/ui/components/full-size-form-text-field/component.tsx
+++ b/src/shared/ui/components/full-size-form-text-field/component.tsx
@@ -2,8 +2,7 @@
 import {
 	KeyboardEvent,
 	InputHTMLAttributes,
-	forwardRef,
-	ForwardedRef,
+	RefObject,
 	useState,
 	useMemo,
 } from "react";
@@ -23,106 +22,108 @@ type Props = InputHTMLAttributes<HTMLInputElement> & {
 	shouldShowErrorAfterTouch?: boolean;
 	onEnter?: () => void;
 	validate?: TextFieldProps["validate"];
+	ref?:
+		| RefObject<HTMLInputElement | null>
+		| ((instance: HTMLInputElement | null) => void);
 };
 
-export const FullSizeFormTextInput = forwardRef(
-	(props: Props, ref: ForwardedRef<HTMLInputElement>) => {
-		const {
-			onEnter,
-			maxLength,
-			error,
-			label,
-			isInvalid,
-			validate,
-			shouldShowErrorAfterTouch,
-			...inputProps
-		} = props;
+export function FullSizeFormTextInput(props: Props) {
+	const {
+		onEnter,
+		maxLength,
+		error,
+		label,
+		isInvalid,
+		validate,
+		shouldShowErrorAfterTouch,
+		ref,
+		...inputProps
+	} = props;
 
-		const [isTouched, setIsTouched] = useState(false);
-		const isInvalidFinal = useMemo(() => {
-			const isInvalidFull = isInvalid || !!error;
-			if (shouldShowErrorAfterTouch) {
-				return isTouched ? isInvalidFull : false;
-			}
-			return isInvalidFull;
-		}, [isTouched, isInvalid, shouldShowErrorAfterTouch, error]);
+	const [isTouched, setIsTouched] = useState(false);
+	const isInvalidFinal = useMemo(() => {
+		const isInvalidFull = isInvalid || !!error;
+		if (shouldShowErrorAfterTouch) {
+			return isTouched ? isInvalidFull : false;
+		}
+		return isInvalidFull;
+	}, [isTouched, isInvalid, shouldShowErrorAfterTouch, error]);
 
-		const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-			if (!isTouched) {
-				setIsTouched(true);
-			}
-			if (e.key === "Enter" && onEnter) {
-				onEnter();
-				e.preventDefault();
-			}
-		};
+	const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (!isTouched) {
+			setIsTouched(true);
+		}
+		if (e.key === "Enter" && onEnter) {
+			onEnter();
+			e.preventDefault();
+		}
+	};
 
-		const onBlur = () => {
-			if (!isTouched) {
-				setIsTouched(true);
-			}
-		};
+	const onBlur = () => {
+		if (!isTouched) {
+			setIsTouched(true);
+		}
+	};
 
-		const charsCount = inputProps.value?.toString().length || 0;
+	const charsCount = inputProps.value?.toString().length || 0;
 
-		return (
-			<TextField
-				className="relative flex flex-col"
-				validate={validate}
-				isInvalid={isInvalidFinal}
-			>
-				<Label className="label mb-4 text-lg text-neutral-900">
-					{label}
-				</Label>
-				<div className="mb-2">
-					<Input
-						type="text"
-						autoComplete="off"
-						onKeyDown={onKeyDown}
-						onBlur={onBlur}
-						ref={ref}
-						{...inputProps}
-						className={twMerge(
-							"h-20 min-w-[400px] text-6xl font-semibold text-neutral-900 outline-hidden placeholder:text-neutral-400",
-							inputProps.className,
-						)}
-						data-testid={`${inputProps.name || ""}-text-field`}
-					/>
-				</div>
-
-				<div className="flex h-5 flex-row gap-1">
-					{maxLength && charsCount > 0 && (
-						<span
-							className={`text-sm ${charsCount > maxLength ? "text-error-600 font-semibold" : "text-neutral-700"}`}
-							data-testid="length-state"
-						>
-							{charsCount}/{maxLength}
-						</span>
+	return (
+		<TextField
+			className="relative flex flex-col"
+			validate={validate}
+			isInvalid={isInvalidFinal}
+		>
+			<Label className="label mb-4 text-lg text-neutral-900">
+				{label}
+			</Label>
+			<div className="mb-2">
+				<Input
+					type="text"
+					autoComplete="off"
+					onKeyDown={onKeyDown}
+					onBlur={onBlur}
+					ref={ref}
+					{...inputProps}
+					className={twMerge(
+						"h-20 min-w-[400px] text-6xl font-semibold text-neutral-900 outline-hidden placeholder:text-neutral-400",
+						inputProps.className,
 					)}
-					<FieldError
-						className="text-error-600 text-sm"
-						data-testid={`${inputProps.name || ""}-error-msg`}
-					>
-						{(renderProps) => {
-							if (error) return error;
-							return renderProps.validationErrors[0];
-						}}
-					</FieldError>
-				</div>
+					data-testid={`${inputProps.name || ""}-text-field`}
+				/>
+			</div>
 
-				{charsCount > 0 && (
-					<div
-						className="absolute -bottom-3 left-0 translate-y-full flex flex-row items-center gap-2 text-sm text-neutral-700"
-						data-testid="enter-shortcut"
+			<div className="flex h-5 flex-row gap-1">
+				{maxLength && charsCount > 0 && (
+					<span
+						className={`text-sm ${charsCount > maxLength ? "text-error-600 font-semibold" : "text-neutral-700"}`}
+						data-testid="length-state"
 					>
-						Press
-						<div className="animate-downOut rounded-sm border border-neutral-600 px-2 py-1 text-sm text-neutral-700">
-							↵ Enter
-						</div>
-						to continue
-					</div>
+						{charsCount}/{maxLength}
+					</span>
 				)}
-			</TextField>
-		);
-	},
-);
+				<FieldError
+					className="text-error-600 text-sm"
+					data-testid={`${inputProps.name || ""}-error-msg`}
+				>
+					{(renderProps) => {
+						if (error) return error;
+						return renderProps.validationErrors[0];
+					}}
+				</FieldError>
+			</div>
+
+			{charsCount > 0 && (
+				<div
+					className="absolute -bottom-3 left-0 translate-y-full flex flex-row items-center gap-2 text-sm text-neutral-700"
+					data-testid="enter-shortcut"
+				>
+					Press
+					<div className="animate-downOut rounded-sm border border-neutral-600 px-2 py-1 text-sm text-neutral-700">
+						↵ Enter
+					</div>
+					to continue
+				</div>
+			)}
+		</TextField>
+	);
+}

--- a/src/shared/ui/components/inline-edit/component.tsx
+++ b/src/shared/ui/components/inline-edit/component.tsx
@@ -78,6 +78,7 @@ export const InlineEdit = (props: InlineEditProps) => {
 						withShadow: !keepEditViewOpenOnBlur,
 					})}
 					data-testid={`${id}-confirm-button`}
+					aria-label="Confirm changes"
 					{...confirmBtnProps}
 				>
 					<CheckIcon size={18} />
@@ -89,6 +90,7 @@ export const InlineEdit = (props: InlineEditProps) => {
 						withShadow: !keepEditViewOpenOnBlur,
 					})}
 					data-testid={`${id}-cancel-button`}
+					aria-label="Cancel changes"
 					{...cancelBtnProps}
 				>
 					<CloseIcon size={18} />
@@ -104,7 +106,10 @@ export const InlineEdit = (props: InlineEditProps) => {
 		>
 			<div ref={viewContainerRef} className="flex flex-col gap-1">
 				{label && (
-					<Label className="px-1 text-xs font-medium text-neutral-900">
+					<Label
+						aria-label={`${label} label`}
+						className="px-1 text-xs font-medium text-neutral-900"
+					>
 						{label}
 					</Label>
 				)}
@@ -114,6 +119,7 @@ export const InlineEdit = (props: InlineEditProps) => {
 						className="outline-primary-500 rounded-lg text-left"
 						isDisabled={isDisabled}
 						data-testid={`${id}-read-view`}
+						aria-label={`${label} read view`}
 					>
 						{readView({ value: state.editorValue })}
 					</AriaButton>

--- a/src/shared/ui/components/inline-edit/components/popover-without-focus-management.tsx
+++ b/src/shared/ui/components/inline-edit/components/popover-without-focus-management.tsx
@@ -1,5 +1,5 @@
 import { setRefs, useEnterAnimation, useExitAnimation } from "@/src/shared/lib";
-import { forwardRef, ReactNode, RefObject, useRef } from "react";
+import { ReactNode, RefObject, useRef } from "react";
 import { usePopover } from "react-aria";
 import { PopoverProps as AriaPopoverProps } from "react-aria-components";
 import { OverlayTriggerState } from "react-stately";
@@ -45,12 +45,18 @@ interface PopoverInnerProps extends AriaPopoverProps {
 	triggerRef: RefObject<HTMLDivElement | null>;
 	className?: string;
 	id: string;
+	ref?: RefObject<HTMLDivElement | null>;
 }
 
-const PopoverWithoutFocusManagmentInner = forwardRef<
-	HTMLDivElement,
-	PopoverInnerProps
->(({ children, state, offset = 8, className, isExiting, ...props }, ref) => {
+function PopoverWithoutFocusManagmentInner({
+	children,
+	state,
+	offset = 8,
+	className,
+	isExiting,
+	ref,
+	...props
+}: PopoverInnerProps) {
 	const popoverRef = useRef<HTMLDivElement | null>(null);
 	const isEntering =
 		useEnterAnimation(popoverRef, !!props.placement) ||
@@ -79,4 +85,4 @@ const PopoverWithoutFocusManagmentInner = forwardRef<
 			{children}
 		</div>
 	);
-});
+}

--- a/src/shared/ui/components/inline-edit/inline-edit.test.tsx
+++ b/src/shared/ui/components/inline-edit/inline-edit.test.tsx
@@ -22,7 +22,12 @@ function InlineEditRenderer({ isDisabled, isInvalid }: Props) {
 				value={value}
 				id="inline-edit"
 				editView={(renderProps) => (
-					<Input label="" {...renderProps} autoFocus />
+					<Input
+						label=""
+						aria-label="Inline Edit Label input"
+						{...renderProps}
+						autoFocus
+					/>
 				)}
 				readView={() => <p className="border p-2">Value: {value}</p>}
 				onConfirm={setValue}

--- a/src/shared/ui/components/input/component.tsx
+++ b/src/shared/ui/components/input/component.tsx
@@ -1,6 +1,5 @@
 "use client";
 import {
-	forwardRef,
 	ReactNode,
 	RefObject,
 	useCallback,
@@ -34,131 +33,128 @@ type _InputProps = {
 	endContent?: ReactNode;
 	isPending?: boolean;
 	"data-testid"?: string;
+	ref?:
+		| RefObject<HTMLInputElement | null>
+		| ((instance: HTMLInputElement | null) => void);
 } & TextFieldProps &
 	Omit<AriaInputProps, "onChange" | "onKeyDown" | "onKeyUp" | "disabled">;
 
-export const Input = forwardRef<HTMLInputElement, _InputProps>(
-	function (props, ref) {
-		const {
-			label,
-			startIcon,
-			errors,
-			withErrorIcon,
-			endContent,
-			className,
-			isPending,
-			errorDefaultOpen,
-			validate,
-			...restProps
-		} = props;
+export function Input(props: _InputProps) {
+	const {
+		label,
+		startIcon,
+		errors,
+		withErrorIcon,
+		endContent,
+		className,
+		isPending,
+		errorDefaultOpen,
+		validate,
+		ref,
+		...restProps
+	} = props;
 
-		const inputRef: RefObject<HTMLInputElement | null> =
-			useRef<HTMLInputElement>(null);
+	const inputRef: RefObject<HTMLInputElement | null> =
+		useRef<HTMLInputElement>(null);
 
-		const [innerError, setInnerError] = useState<string | true | null>(
-			null,
-		);
-		const onValidationCheck = useCallback(
-			(value: string) => {
-				if (!validate) return;
-				const error = validate(value) || null;
-				setInnerError(Array.isArray(error) ? error[0] : error);
-			},
-			[validate],
-		);
+	const [innerError, setInnerError] = useState<string | true | null>(null);
+	const onValidationCheck = useCallback(
+		(value: string) => {
+			if (!validate) return;
+			const error = validate(value) || null;
+			setInnerError(Array.isArray(error) ? error[0] : error);
+		},
+		[validate],
+	);
 
-		const error = useMemo(() => {
-			const outerError =
-				typeof errors === "string"
-					? errors
-					: Array.isArray(errors)
-						? errors[0]
-						: undefined;
+	const error = useMemo(() => {
+		const outerError =
+			typeof errors === "string"
+				? errors
+				: Array.isArray(errors)
+					? errors[0]
+					: undefined;
 
-			return outerError || innerError;
-		}, [errors, innerError]);
+		return outerError || innerError;
+	}, [errors, innerError]);
 
-		const mergedProps = mergeProps(restProps, {
-			onChange: onValidationCheck,
-		});
+	const mergedProps = mergeProps(restProps, {
+		onChange: onValidationCheck,
+	});
 
-		return (
-			<TextField
-				className="group flex w-full flex-col"
-				{...mergedProps}
-				isDisabled={restProps.isDisabled || isPending}
-				data-testid="text-field-container"
-				validationBehavior="aria"
-				isInvalid={!!errors || restProps.isInvalid}
-			>
-				<Label aria-label="Label">
-					<span
-						className={labelStyles({
+	return (
+		<TextField
+			className="group flex w-full flex-col"
+			{...mergedProps}
+			isDisabled={restProps.isDisabled || isPending}
+			data-testid="text-field-container"
+			validationBehavior="aria"
+			isInvalid={!!errors || restProps.isInvalid}
+		>
+			<Label aria-label={`${label} label`}>
+				<span
+					className={labelStyles({
+						isDisabled: !!restProps.isDisabled || !!isPending,
+						hasContent: !!label,
+					})}
+				>
+					{label}
+				</span>
+
+				<Group
+					className={twMerge(
+						inputStyles({
+							hasError: !!errors?.length,
+							hasEndContent: !!endContent,
 							isDisabled: !!restProps.isDisabled || !!isPending,
-							hasContent: !!label,
-						})}
-					>
-						{label}
-					</span>
-
-					<Group
-						className={twMerge(
-							inputStyles({
-								hasError: !!errors?.length,
-								hasEndContent: !!endContent,
-								isDisabled:
-									!!restProps.isDisabled || !!isPending,
-							}),
-							className as string,
-						)}
-					>
-						{startIcon && (
-							<span className="text-neutral-500">
-								{startIcon({ size: 12, thikness: "bold" })}
-							</span>
-						)}
-						<AriaInput
-							className="h-full w-full bg-white/0 outline-hidden placeholder:text-neutral-600"
-							aria-label="input"
-							data-testid={restProps["data-testid"]}
-							ref={setRefs(inputRef, ref)}
+						}),
+						className as string,
+					)}
+				>
+					{startIcon && (
+						<span className="text-neutral-500">
+							{startIcon({ size: 12, thikness: "bold" })}
+						</span>
+					)}
+					<AriaInput
+						className="h-full w-full bg-white/0 outline-hidden placeholder:text-neutral-600"
+						aria-label={label || undefined}
+						data-testid={restProps["data-testid"]}
+						ref={setRefs(inputRef, ref)}
+					/>
+					{endContent}
+					{withErrorIcon && typeof error === "string" && (
+						<FieldErrorIcon
+							errorMsg={error}
+							placement="top end"
+							defaultOpen={errorDefaultOpen}
 						/>
-						{endContent}
-						{withErrorIcon && typeof error === "string" && (
-							<FieldErrorIcon
-								errorMsg={error}
-								placement="top end"
-								defaultOpen={errorDefaultOpen}
-							/>
-						)}
-						{isPending && (
-							<div className="border-r-primary-500 animate-rotation-linear aspect-square w-4 rounded-full border-2 border-y-neutral-200 border-l-neutral-200" />
-						)}
-					</Group>
-				</Label>
+					)}
+					{isPending && (
+						<div className="border-r-primary-500 animate-rotation-linear aspect-square w-4 rounded-full border-2 border-y-neutral-200 border-l-neutral-200" />
+					)}
+				</Group>
+			</Label>
 
-				{!withErrorIcon && (
-					<FieldError className="text-error-700 flex w-full flex-row items-center gap-2 p-1 text-start text-xs font-medium">
-						{(renderProps) => {
-							if (!error && !renderProps.isInvalid) return null;
+			{!withErrorIcon && (
+				<FieldError className="text-error-700 flex w-full flex-row items-center gap-2 p-1 text-start text-xs font-medium">
+					{(renderProps) => {
+						if (!error && !renderProps.isInvalid) return null;
 
-							return (
-								<>
-									<WarningIcon size={14} thikness="bold" />
-									{error || renderProps.validationErrors[0]}
-								</>
-							);
-						}}
-					</FieldError>
-				)}
-			</TextField>
-		);
-	},
-);
+						return (
+							<>
+								<WarningIcon size={14} thikness="bold" />
+								{error || renderProps.validationErrors[0]}
+							</>
+						);
+					}}
+				</FieldError>
+			)}
+		</TextField>
+	);
+}
 
-export type InputProps = _InputProps & {
-	ref?: RefObject<HTMLInputElement>;
-};
+export type InputProps = _InputProps;
 
 const inputStyles = cva(
 	[

--- a/src/shared/ui/components/list/components/list.tsx
+++ b/src/shared/ui/components/list/components/list.tsx
@@ -1,11 +1,17 @@
-import { ForwardedRef, forwardRef, JSX } from "react";
+import { JSX, RefObject } from "react";
 import { AriaListBoxOptions } from "react-aria";
 import { ListBox, ListBoxProps } from "react-aria-components";
 
-export const ListWrapper = forwardRef<
-	HTMLDivElement,
-	ListBoxProps<object> & AriaListBoxOptions<object>
->(({ children, className, renderEmptyState, ...restProps }, ref) => {
+export type ListProps<TItemData extends object> = ListBoxProps<TItemData> &
+	AriaListBoxOptions<TItemData> & {
+		ref?: RefObject<HTMLDivElement | null>;
+	};
+
+function _ListWrapper(
+	props: ListBoxProps<object> &
+		AriaListBoxOptions<object> & { ref?: RefObject<HTMLDivElement | null> },
+) {
+	const { children, className, renderEmptyState, ref, ...restProps } = props;
 	const defaultEmptyState = () => (
 		<span className="text-sm text-neutral-800">No results found.</span>
 	);
@@ -20,11 +26,8 @@ export const ListWrapper = forwardRef<
 			{children}
 		</ListBox>
 	);
-}) as unknown as <TItemData extends object>(
+}
+
+export const ListWrapper = _ListWrapper as <TItemData extends object>(
 	props: ListProps<TItemData>,
 ) => JSX.Element;
-
-export type ListProps<TItemData extends object> = ListBoxProps<TItemData> &
-	AriaListBoxOptions<TItemData> & {
-		ref?: ForwardedRef<HTMLDivElement>;
-	};

--- a/src/shared/ui/components/popover/component.tsx
+++ b/src/shared/ui/components/popover/component.tsx
@@ -1,5 +1,5 @@
 import { setRefs } from "@/src/shared/lib";
-import { forwardRef, useCallback, useRef } from "react";
+import { RefObject, useCallback, useRef } from "react";
 import {
 	PopoverProps,
 	DialogTriggerProps,
@@ -22,64 +22,63 @@ type PopoverContentProps = Omit<
 > & {
 	children: DialogProps["children"];
 	widthType?: "auto" | "equalToTrigger";
+	ref?: RefObject<HTMLElement | null>;
 };
 
-const PopoverContent = forwardRef<HTMLElement, PopoverContentProps>(
-	(props, ref) => {
-		const { children, className, widthType, triggerRef, ...restProps } =
-			props;
+function PopoverContent(props: PopoverContentProps) {
+	const { children, className, widthType, triggerRef, ref, ...restProps } =
+		props;
 
-		const popoverRef = useRef<HTMLElement | null>(null);
+	const popoverRef = useRef<HTMLElement | null>(null);
 
-		const getPopoverWidth = useCallback(() => {
-			const trggerElement = triggerRef?.current;
+	const getPopoverWidth = useCallback(() => {
+		const trggerElement = triggerRef?.current;
 
-			if (widthType === "equalToTrigger" && !trggerElement) {
-				console.warn(
-					"Please provide triggerRef if you want to use widthType=equalToTrigger",
-				);
-			}
-			if (widthType === "equalToTrigger" && trggerElement) {
-				return `${trggerElement.getBoundingClientRect().width}px`;
-			}
-			return "auto";
-		}, [widthType, triggerRef]);
+		if (widthType === "equalToTrigger" && !trggerElement) {
+			console.warn(
+				"Please provide triggerRef if you want to use widthType=equalToTrigger",
+			);
+		}
+		if (widthType === "equalToTrigger" && trggerElement) {
+			return `${trggerElement.getBoundingClientRect().width}px`;
+		}
+		return "auto";
+	}, [widthType, triggerRef]);
 
-		return (
-			<Popover
+	return (
+		<Popover
+			{...restProps}
+			triggerRef={triggerRef}
+			ref={setRefs(popoverRef, ref)}
+			style={() => ({
+				width: getPopoverWidth(),
+			})}
+			className="data-entering:animate-popup data-exiting:animate-popup-reverse"
+		>
+			<Dialog
 				{...restProps}
-				triggerRef={triggerRef}
-				ref={setRefs(popoverRef, ref)}
-				style={() => ({
-					width: getPopoverWidth(),
-				})}
-				className="data-entering:animate-popup data-exiting:animate-popup-reverse"
+				className={
+					"outline-hidden bg-white border border-neutral-100 rounded-lg drop-shadow-lg max-h-[inherit] overflow-hidden " +
+					className
+				}
 			>
-				<Dialog
-					{...restProps}
-					className={
-						"outline-hidden bg-white border border-neutral-100 rounded-lg drop-shadow-lg max-h-[inherit] overflow-hidden " +
-						className
-					}
-				>
-					{(renderProps) => (
-						<ButtonContext.Provider
-							value={{
-								slots: {
-									close: { onPress: renderProps.close },
-								},
-							}}
-						>
-							{typeof children === "function"
-								? children(renderProps)
-								: children}
-						</ButtonContext.Provider>
-					)}
-				</Dialog>
-			</Popover>
-		);
-	},
-);
+				{(renderProps) => (
+					<ButtonContext.Provider
+						value={{
+							slots: {
+								close: { onPress: renderProps.close },
+							},
+						}}
+					>
+						{typeof children === "function"
+							? children(renderProps)
+							: children}
+					</ButtonContext.Provider>
+				)}
+			</Dialog>
+		</Popover>
+	);
+}
 
 const _Popover = Object.assign(PopoverTrigger, {
 	Content: PopoverContent,

--- a/src/shared/ui/components/radio-group/component.tsx
+++ b/src/shared/ui/components/radio-group/component.tsx
@@ -1,7 +1,7 @@
 import { buildProvider } from "@/src/shared/lib";
 import { mergeClassNames } from "@/src/shared/lib/utils/merge-class-names";
 import { cva } from "class-variance-authority";
-import { forwardRef, useMemo } from "react";
+import { RefObject, useMemo } from "react";
 import {
 	RadioGroup as RadioGroupAria,
 	RadioGroupProps as RadioGroupAriaProps,
@@ -17,14 +17,16 @@ import { twMerge } from "tailwind-merge";
 type RadioGrouProps = {
 	variant?: "default" | "content-inside";
 	size?: "default" | "large";
+	ref?: RefObject<HTMLDivElement | null>;
 } & RadioGroupAriaProps;
 
-const _RadioGroup = forwardRef<HTMLDivElement, RadioGrouProps>((props, ref) => {
+function RadioGroupInner(props: RadioGrouProps) {
 	const {
 		children,
 		variant = "default",
 		size = "default",
 		className,
+		ref,
 		...restProps
 	} = props;
 
@@ -44,7 +46,7 @@ const _RadioGroup = forwardRef<HTMLDivElement, RadioGrouProps>((props, ref) => {
 			</RadioGroupAria>
 		</RadioGroupProvider>
 	);
-});
+}
 
 export const radioStyles = cva(["text-neutral-900", "transition-colors"], {
 	variants: {
@@ -151,7 +153,7 @@ const Description = (props: TextProps) => {
 	);
 };
 
-export const RadioGroup = Object.assign(_RadioGroup, {
+export const RadioGroup = Object.assign(RadioGroupInner, {
 	Radio,
 	Label,
 	Description,

--- a/src/shared/ui/components/select/component.tsx
+++ b/src/shared/ui/components/select/component.tsx
@@ -21,6 +21,7 @@ type SelectProps<TItemData extends object> = {
 	description?: string;
 	isDisabled?: boolean;
 	errorMessages?: string[];
+	"aria-label"?: string;
 } & UseSelectProps<TItemData> &
 	AriaFieldProps;
 
@@ -34,6 +35,7 @@ function Select<TItemData extends object>(props: SelectProps<TItemData>) {
 		children,
 		items,
 		id: externalId,
+		"aria-label": ariaLabel,
 		...restProps
 	} = props;
 	const internalId = useId();
@@ -130,7 +132,7 @@ function Select<TItemData extends object>(props: SelectProps<TItemData>) {
 				ref={popoverRef}
 				widthType="equalToTrigger"
 				placement="bottom left"
-				aria-label="Select Items"
+				aria-label={ariaLabel || label || "Select options"}
 				maxHeight={300}
 				shouldCloseOnInteractOutside={() => false}
 				isNonModal

--- a/src/shared/ui/components/select/components/select-value.tsx
+++ b/src/shared/ui/components/select/components/select-value.tsx
@@ -153,7 +153,7 @@ const MultipleSelectionValue = () => {
 			<AriaButton
 				isDisabled={ctx.isDisabled}
 				onPress={ctx.overlayTriggerState.toggle}
-				aria-label="Add Items"
+				aria-label={`Add ${ctx.placeholder?.toLowerCase() || "items"}`}
 				className="flex max-h-[21px] flex-row items-center gap-2 rounded-sm bg-neutral-300 px-2 py-1 text-xs text-neutral-900 hover:disabled:cursor-not-allowed"
 				{...ctx.fieldProps}
 			>

--- a/src/shared/ui/components/switch/component.tsx
+++ b/src/shared/ui/components/switch/component.tsx
@@ -1,38 +1,35 @@
-import { forwardRef, ForwardedRef } from "react";
+import { RefObject } from "react";
 import { useObjectRef } from "react-aria";
 import { Checkbox, CheckboxProps } from "react-aria-components";
 
 type Props = {
 	label?: string;
 	description?: string;
+	ref?: RefObject<HTMLInputElement | null>;
 } & Omit<CheckboxProps, "children">;
 
-export const Switch = forwardRef(
-	(props: Props, ref: ForwardedRef<HTMLInputElement>) => {
-		const { label, description, ...checkboxProps } = props;
-		const inputRef = useObjectRef(ref);
-		return (
-			<Checkbox
-				className="group flex cursor-pointer flex-row items-center gap-2"
-				inputRef={inputRef}
-				{...checkboxProps}
+export function Switch(props: Props) {
+	const { label, description, ref, ...checkboxProps } = props;
+	const inputRef = useObjectRef(ref);
+	return (
+		<Checkbox
+			className="group flex cursor-pointer flex-row items-center gap-2"
+			inputRef={inputRef}
+			{...checkboxProps}
+		>
+			<div
+				data-testid="switch-container"
+				className="group-has-checked:bg-primary-500 group-has-[:checked]:checked-state group-data-[focused=true]:outline-primary-500 relative block h-[24px] min-h-[24px] w-[42px] min-w-[42px] shrink cursor-pointer rounded-[24px] bg-neutral-300 shadow-inner transition-all group-has-disabled:bg-neutral-100 group-has-disabled:cursor-not-allowed group-data-[focused=true]:outline group-data-[focused=true]:outline-offset-2"
 			>
-				<div
-					data-testid="switch-container"
-					className="group-has-checked:bg-primary-500 group-has-[:checked]:checked-state group-data-[focused=true]:outline-primary-500 relative block h-[24px] min-h-[24px] w-[42px] min-w-[42px] shrink cursor-pointer rounded-[24px] bg-neutral-300 shadow-inner transition-all group-has-disabled:bg-neutral-100 group-has-disabled:cursor-not-allowed group-data-[focused=true]:outline group-data-[focused=true]:outline-offset-2"
-				>
-					<div className="absolute top-1 flex h-[16px] w-[16px] translate-x-1 items-center justify-center rounded-[16px] bg-white drop-shadow-md transition-all group-active:w-[20px] group-has-checked:translate-x-[21px] group-active:group-has-checked:translate-x-[17px] group-has-disabled:bg-neutral-400"></div>
-				</div>
+				<div className="absolute top-1 flex h-[16px] w-[16px] translate-x-1 items-center justify-center rounded-[16px] bg-white drop-shadow-md transition-all group-active:w-[20px] group-has-checked:translate-x-[21px] group-active:group-has-checked:translate-x-[17px] group-has-disabled:bg-neutral-400"></div>
+			</div>
 
-				<div className="flex flex-col">
-					<span className="text-sm text-neutral-900 group-has-disabled:text-neutral-600">
-						{label}
-					</span>
-					<span className="text-xs text-neutral-700">
-						{description}
-					</span>
-				</div>
-			</Checkbox>
-		);
-	},
-);
+			<div className="flex flex-col">
+				<span className="text-sm text-neutral-900 group-has-disabled:text-neutral-600">
+					{label}
+				</span>
+				<span className="text-xs text-neutral-700">{description}</span>
+			</div>
+		</Checkbox>
+	);
+}

--- a/src/shared/ui/components/textarea/component.tsx
+++ b/src/shared/ui/components/textarea/component.tsx
@@ -1,7 +1,7 @@
 import {
 	FormEvent,
 	FormEventHandler,
-	forwardRef,
+	RefObject,
 	useCallback,
 	useEffect,
 	useRef,
@@ -29,109 +29,111 @@ type TextAreaProps = {
 	isPending?: boolean;
 	maxHeight?: number;
 	rows?: number;
+	ref?: RefObject<HTMLTextAreaElement | null>;
 } & TextFieldProps;
 
-export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-	function (props, ref) {
-		const {
-			label,
-			error,
-			withErrorIcon,
-			className,
-			isPending,
-			maxHeight,
-			rows = 4,
-			...restProps
-		} = props;
+export function TextArea(props: TextAreaProps) {
+	const {
+		label,
+		error,
+		withErrorIcon,
+		className,
+		isPending,
+		maxHeight,
+		rows = 4,
+		ref,
+		...restProps
+	} = props;
 
-		// Computed values to reduce complexity
-		const isFieldDisabled = !!restProps.isDisabled || !!isPending;
-		const hasError = !!error?.length;
-		const isInvalid = !!error || !!restProps.isInvalid;
-		const hasLabel = !!label;
-		const maxHeightStyle = maxHeight ? `${maxHeight}px` : "inherit";
+	// Computed values to reduce complexity
+	const isFieldDisabled = !!restProps.isDisabled || !!isPending;
+	const hasError = !!error?.length;
+	const isInvalid = !!error || !!restProps.isInvalid;
+	const hasLabel = !!label;
+	const maxHeightStyle = maxHeight ? `${maxHeight}px` : "inherit";
 
-		const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
+	const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
 
-		useEffect(() => {
-			const textAreaEl = textAreaRef.current;
-			if (!textAreaEl) return;
+	useEffect(() => {
+		const textAreaEl = textAreaRef.current;
+		if (!textAreaEl) return;
 
-			textAreaEl.style.height = "auto";
-			textAreaEl.style.height = `${textAreaEl.scrollHeight}px`;
-		}, [textAreaRef]);
+		textAreaEl.style.height = "auto";
+		textAreaEl.style.height = `${textAreaEl.scrollHeight}px`;
+	}, [textAreaRef]);
 
-		const onInternalInput: FormEventHandler<HTMLTextAreaElement> =
-			useCallback((ev: FormEvent<HTMLTextAreaElement>) => {
-				const el = ev.currentTarget;
-				el.style.height = "auto";
-				el.style.height = `${el.scrollHeight}px`;
-			}, []);
+	const onInternalInput: FormEventHandler<HTMLTextAreaElement> = useCallback(
+		(ev: FormEvent<HTMLTextAreaElement>) => {
+			const el = ev.currentTarget;
+			el.style.height = "auto";
+			el.style.height = `${el.scrollHeight}px`;
+		},
+		[],
+	);
 
-		return (
-			<TextField
-				className="group flex w-full flex-col"
-				{...mergeProps(restProps, { onInput: onInternalInput })}
-				isDisabled={isFieldDisabled}
-				data-testid="text-field-container"
-				isInvalid={isInvalid}
-			>
-				<Label aria-label="Label">
-					<span
-						className={labelStyles({
+	return (
+		<TextField
+			className="group flex w-full flex-col"
+			{...mergeProps(restProps, { onInput: onInternalInput })}
+			isDisabled={isFieldDisabled}
+			data-testid="text-field-container"
+			isInvalid={isInvalid}
+		>
+			<Label>
+				<span
+					className={labelStyles({
+						isDisabled: isFieldDisabled,
+						hasContent: hasLabel,
+					})}
+				>
+					{label}
+				</span>
+
+				<Group
+					className={twMerge(
+						textAreaStyles({
+							hasError,
 							isDisabled: isFieldDisabled,
-							hasContent: hasLabel,
-						})}
-					>
-						{label}
-					</span>
-
-					<Group
-						className={twMerge(
-							textAreaStyles({
-								hasError,
-								isDisabled: isFieldDisabled,
-							}),
-							className as string,
-						)}
-						onClick={() => {
-							textAreaRef.current?.focus();
+						}),
+						className as string,
+					)}
+					onClick={() => {
+						textAreaRef.current?.focus();
+					}}
+				>
+					<AriaTextArea
+						className="h-full w-full overflow-hidden bg-white/0 outline-hidden placeholder:text-neutral-600"
+						aria-label={label || undefined}
+						rows={rows}
+						ref={setRefs(textAreaRef, ref)}
+						style={{
+							maxHeight: maxHeightStyle,
 						}}
-					>
-						<AriaTextArea
-							className="h-full w-full overflow-hidden bg-white/0 outline-hidden placeholder:text-neutral-600"
-							aria-label="textarea"
-							rows={rows}
-							ref={setRefs(textAreaRef, ref)}
-							style={{
-								maxHeight: maxHeightStyle,
-							}}
-						/>
-						<div className="absolute top-2 right-2 flex flex-col items-center gap-1">
-							{withErrorIcon && (
-								<FieldErrorIcon
-									errorMsg={error}
-									placement="top end"
-									size={16}
-								/>
-							)}
-							{isPending && (
-								<div className="border-r-primary-500 animate-rotation-linear aspect-square w-4 rounded-full border-2 border-neutral-500" />
-							)}
-						</div>
-					</Group>
-				</Label>
+					/>
+					<div className="absolute top-2 right-2 flex flex-col items-center gap-1">
+						{withErrorIcon && (
+							<FieldErrorIcon
+								errorMsg={error}
+								placement="top end"
+								size={16}
+							/>
+						)}
+						{isPending && (
+							<div className="border-r-primary-500 animate-rotation-linear aspect-square w-4 rounded-full border-2 border-neutral-500" />
+						)}
+					</div>
+				</Group>
+			</Label>
 
-				{!withErrorIcon && (
-					<FieldError className="text-error-700 flex w-full flex-row items-center gap-1 p-1 text-xs font-medium">
-						<WarningIcon size={12} thikness="bold" />
-						{error}
-					</FieldError>
-				)}
-			</TextField>
-		);
-	},
-);
+			{!withErrorIcon && (
+				<FieldError className="text-error-700 flex w-full flex-row items-center gap-1 p-1 text-xs font-medium">
+					<WarningIcon size={12} thikness="bold" />
+					{error}
+				</FieldError>
+			)}
+		</TextField>
+	);
+}
 
 const textAreaStyles = cva(
 	[

--- a/src/shared/ui/next-components/next-link/component.tsx
+++ b/src/shared/ui/next-components/next-link/component.tsx
@@ -1,6 +1,5 @@
 import NextLink, { LinkProps as NextLinkProps } from "next/link";
-import { CSSProperties, ForwardedRef, forwardRef, ReactNode } from "react";
-import { forwardRefType } from "@react-types/shared/src/refs";
+import { CSSProperties, ReactNode, RefObject } from "react";
 import {
 	RenderProps,
 	useRenderProps,
@@ -40,28 +39,28 @@ export type NextLinkButtonProps = LinkButtonProps &
 	Omit<AriaLinkOptions, "elementType"> &
 	HoverEvents &
 	RenderProps<LinkRenderProps> &
-	SlotProps;
+	SlotProps & {
+		ref?: RefObject<HTMLAnchorElement | null>;
+	};
 
-function NextLinkButton(
-	props: NextLinkButtonProps,
-	ref: ForwardedRef<HTMLAnchorElement>,
-) {
-	[props, ref] = useContextProps(props, ref, LinkContext);
+export function NextLinkButton(props: NextLinkButtonProps) {
+	let { ref, ...restProps } = props;
+	[restProps, ref] = useContextProps(restProps, ref, LinkContext);
 	const {
 		size = "medium",
 		variant = "default",
 		appearance = "primary",
-	} = props;
+	} = restProps;
 
-	const isDisabled = props.isDisabled || false;
-	const slotValue = props.slot || undefined;
+	const isDisabled = restProps.isDisabled || false;
+	const slotValue = restProps.slot || undefined;
 
 	const { linkProps, isPressed } = useLink(
-		{ ...props, elementType: "a" },
+		{ ...restProps, elementType: "a" },
 		ref,
 	);
 
-	const { hoverProps, isHovered } = useHover(props);
+	const { hoverProps, isHovered } = useHover(restProps);
 	const { focusProps, isFocused, isFocusVisible } = useFocusRing();
 
 	const dataFocused = isFocused || undefined;
@@ -71,7 +70,7 @@ function NextLinkButton(
 	const dataDisabled = isDisabled || undefined;
 
 	const renderProps = useRenderProps({
-		...props,
+		...restProps,
 		defaultClassName: "",
 		values: {
 			isCurrent: false,
@@ -102,7 +101,7 @@ function NextLinkButton(
 			{...mergeProps(renderProps, linkProps, hoverProps, focusProps)}
 			style={COLOR_SCHEMES[appearance] as CSSProperties}
 			className={btnStyles()}
-			href={props.href}
+			href={restProps.href}
 			slot={slotValue}
 			data-focused={dataFocused}
 			data-hovered={dataHovered}
@@ -115,36 +114,33 @@ function NextLinkButton(
 	);
 }
 
-const _NextLinkButton = (forwardRef as forwardRefType)(NextLinkButton);
-export { _NextLinkButton as NextLinkButton };
-
 export type NextPlainLinkProps = LinkProps &
 	NextLinkProps &
 	Omit<AriaLinkOptions, "elementType"> &
 	HoverEvents &
 	RenderProps<LinkRenderProps> &
-	SlotProps;
+	SlotProps & {
+		ref?: RefObject<HTMLAnchorElement | null>;
+	};
 
-function NextCustomLink(
-	props: NextPlainLinkProps,
-	ref: ForwardedRef<HTMLAnchorElement>,
-) {
-	[props, ref] = useContextProps(props, ref, LinkContext);
+export function NextLink_(props: NextPlainLinkProps) {
+	let { ref, ...restProps } = props;
+	[restProps, ref] = useContextProps(restProps, ref, LinkContext);
 
 	const { linkProps, isPressed } = useLink(
-		{ ...props, elementType: "a" },
+		{ ...restProps, elementType: "a" },
 		ref,
 	);
 
-	const { hoverProps, isHovered } = useHover(props);
+	const { hoverProps, isHovered } = useHover(restProps);
 	const { focusProps, isFocused, isFocusVisible } = useFocusRing();
 
 	const renderProps = useRenderProps({
-		...props,
+		...restProps,
 		defaultClassName: "",
 		values: {
 			isCurrent: false,
-			isDisabled: props.isDisabled || false,
+			isDisabled: restProps.isDisabled || false,
 			isPressed,
 			isHovered,
 			isFocused,
@@ -163,18 +159,18 @@ function NextCustomLink(
 			ref={ref}
 			{...mergeProps(renderProps, linkProps, hoverProps, focusProps)}
 			className={linkStyles()}
-			href={props.href}
-			slot={props.slot || undefined}
+			href={restProps.href}
+			slot={restProps.slot || undefined}
 			data-focused={isFocused || undefined}
 			data-hovered={isHovered || undefined}
 			data-pressed={isPressed || undefined}
 			data-focus-visible={isFocusVisible || undefined}
-			data-disabled={props.isDisabled || undefined}
+			data-disabled={restProps.isDisabled || undefined}
 		>
 			{renderProps.children}
 		</NextLink>
 	);
 }
 
-const _NextLink = (forwardRef as forwardRefType)(NextCustomLink);
-export { _NextLink as NextLink };
+// Export with the original name for backward compatibility
+export { NextLink_ as NextLink };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves accessibility and simplifies ref handling across the UI library.
> 
> - Migrates `Button`, `Input`, `TextArea`, `Switch`, `Popover`, `ListWrapper`, `RadioGroup`, `AutocompleteList`, `FullSizeFormTextInput`, and Next.js link wrappers to function components that accept `ref` via props (using `useContextProps`/`setRefs` where applicable)
> - Standardizes and clarifies ARIA labels and accessible names (e.g., toggle buttons use `"Toggle suggestions"`, drawer buttons/containers accept `"aria-label"`, labels expose meaningful names, Select popover labeled via `aria-label`, chips/selected items labeled)
> - Updates `InlineEdit` to label controls and tests to use explicit labels
> - Minor cleanup: remove debug log from `GameLayout`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 508b47a865a315885b7a58880cddb32fb468036d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->